### PR TITLE
Fix ENABLE_WEBHOOKS behavior

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,9 +145,11 @@ func main() {
 		setupLog.Error(err, "unable to create controller", "controller", "Chyt")
 		os.Exit(1)
 	}
-	if err = (&clusterv1.Chyt{}).SetupWebhookWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create webhook", "webhook", "Chyt")
-		os.Exit(1)
+	if os.Getenv("ENABLE_WEBHOOKS") != "false" {
+		if err = (&clusterv1.Chyt{}).SetupWebhookWithManager(mgr); err != nil {
+			setupLog.Error(err, "unable to create webhook", "webhook", "Chyt")
+			os.Exit(1)
+		}
 	}
 	//+kubebuilder:scaffold:builder
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

Before this commit ENABLE_WEBHOOKS=false does not stop disable CHYT webhooks. This commit achieves the desired behavior.