### PR TITLE
YTNEBIUS-27: request privileged mode for exec node containers by default

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -232,6 +232,8 @@ type ExecNodesSpec struct {
 	Name string `json:"name,omitempty"`
 	// List of sidecar containers as yaml of corev1.Container.
 	Sidecars []string `json:"sidecars,omitempty"`
+	//+kubebuilder:default:=true
+	Privileged bool `json:"privileged"`
 }
 
 type TabletNodesSpec struct {

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -7231,6 +7231,9 @@ spec:
                       additionalProperties:
                         type: string
                       type: object
+                    privileged:
+                      default: true
+                      type: boolean
                     resources:
                       description: ResourceRequirements describes the compute resource
                         requirements.
@@ -8697,6 +8700,8 @@ spec:
                         - name
                         type: object
                       type: array
+                  required:
+                  - privileged
                   type: object
                 type: array
               extraPodAnnotations:


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

This commit makes possible to perform privileged actions on behalf of exec-node, in particular - mount tmpfs in jobs, which currently results in user slot disabling.