### PR TITLE
Introduce postprocess-config init container

### DIFF
--- a/pkg/components/init_job.go
+++ b/pkg/components/init_job.go
@@ -109,7 +109,7 @@ func (j *InitJob) Build() *batchv1.Job {
 				},
 			},
 			Volumes: []corev1.Volume{
-				createConfigVolume(j.configHelper.GetConfigMapName(), &defaultMode),
+				createConfigVolume(consts.ConfigVolumeName, j.configHelper.GetConfigMapName(), &defaultMode),
 			},
 			RestartPolicy: corev1.RestartPolicyOnFailure,
 		},

--- a/pkg/components/strawberry_controller.go
+++ b/pkg/components/strawberry_controller.go
@@ -202,7 +202,7 @@ func (c *strawberryController) syncComponents(ctx context.Context) (err error) {
 	}
 
 	deployment.Spec.Template.Spec.Volumes = []corev1.Volume{
-		createConfigVolume(c.labeller.GetMainConfigMapName(), nil),
+		createConfigVolume(consts.ConfigVolumeName, c.labeller.GetMainConfigMapName(), nil),
 	}
 
 	return c.microservice.Sync(ctx)

--- a/pkg/components/volume.go
+++ b/pkg/components/volume.go
@@ -1,10 +1,12 @@
 package components
 
 import (
+	"fmt"
 	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"path"
 )
 
 func createVolumeClaims(specVolumeClaimTemplates []ytv1.EmbeddedPersistentVolumeClaim) []v1.PersistentVolumeClaim {
@@ -22,24 +24,33 @@ func createVolumeClaims(specVolumeClaimTemplates []ytv1.EmbeddedPersistentVolume
 	return volumeClaims
 }
 
+func createConfigTemplateVolumeMount() v1.VolumeMount {
+	return v1.VolumeMount{
+		Name:      consts.ConfigTemplateVolumeName,
+		MountPath: consts.ConfigTemplateMountPoint,
+		ReadOnly:  true,
+	}
+}
+
 func createConfigVolumeMount() v1.VolumeMount {
 	return v1.VolumeMount{
 		Name:      consts.ConfigVolumeName,
 		MountPath: consts.ConfigMountPoint,
-		ReadOnly:  true,
+		ReadOnly:  false,
 	}
 }
 
 func createVolumeMounts(specVolumeMounts []v1.VolumeMount) []v1.VolumeMount {
 	volumeMounts := make([]v1.VolumeMount, 0, len(specVolumeMounts)+1)
 	volumeMounts = append(volumeMounts, specVolumeMounts...)
+	volumeMounts = append(volumeMounts, createConfigTemplateVolumeMount())
 	volumeMounts = append(volumeMounts, createConfigVolumeMount())
 	return volumeMounts
 }
 
-func createConfigVolume(configMapName string, mode *int32) v1.Volume {
+func createConfigVolume(volumeName string, configMapName string, mode *int32) v1.Volume {
 	return v1.Volume{
-		Name: consts.ConfigVolumeName,
+		Name: volumeName,
 		VolumeSource: v1.VolumeSource{
 			ConfigMap: &v1.ConfigMapVolumeSource{
 				LocalObjectReference: v1.LocalObjectReference{
@@ -51,18 +62,77 @@ func createConfigVolume(configMapName string, mode *int32) v1.Volume {
 	}
 }
 
-func createVolumes(specVolumes []v1.Volume, configMapName string) []v1.Volume {
+func createConfigEmptyDir() v1.Volume {
+	return v1.Volume{
+		Name: consts.ConfigVolumeName,
+		VolumeSource: v1.VolumeSource{
+			EmptyDir: &v1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+func createServerVolumes(specVolumes []v1.Volume, configMapName string) []v1.Volume {
 	volumes := make([]v1.Volume, 0, len(specVolumes)+1)
 	volumes = append(volumes, specVolumes...)
 
-	volumes = append(volumes, createConfigVolume(configMapName, nil))
+	volumes = append(volumes, createConfigVolume(consts.ConfigTemplateVolumeName, configMapName, nil))
+	volumes = append(volumes, createConfigEmptyDir())
 	return volumes
 }
 
 func getLocationInitCommand(locations []ytv1.LocationSpec) string {
-	locationInitCommand := "echo 'Init locations'"
+	command := "echo 'Init locations'; "
 	for _, location := range locations {
-		locationInitCommand += "; mkdir -p " + location.Path
+		command += "mkdir -p " + location.Path + "; "
 	}
-	return locationInitCommand
+	return command
+}
+
+func getConfigPostprocessingCommand(configFileName string) string {
+	command := fmt.Sprintf("echo 'Postprocess config %v';", configFileName)
+
+	// Store postprocessing as a script on filesystem to ease up manual
+	// config re-initialization without pod recreation. This will be useful
+	// when operator starts restarting processes without container recreation.
+
+	configTemplatePath := path.Join(consts.ConfigTemplateMountPoint, configFileName)
+	configPath := path.Join(consts.ConfigMountPoint, configFileName)
+	postprocessScriptPath := path.Join(consts.ConfigMountPoint, consts.PostprocessConfigScriptFileName)
+
+	substituteEnvCommand := func(envVar string) string {
+		// Replace placeholder {envVar} with the actual value of environment variable envVar.
+		return fmt.Sprintf("sed -i -s \"s/{%v}/${%v}/g\" %v; ", envVar, envVar, configPath)
+	}
+
+	postprocessScript := fmt.Sprintf("cp %v %v; ", configTemplatePath, configPath)
+	postprocessScript += substituteEnvCommand("POD_NAME")
+	postprocessScript += substituteEnvCommand("POD_NAMESPACE")
+
+	command += fmt.Sprintf("echo '%v' > %v; ", postprocessScript, postprocessScriptPath)
+	command += fmt.Sprintf("chmod +x '%v'; ", postprocessScriptPath)
+	command += fmt.Sprintf("source %v; ", postprocessScriptPath)
+	command += fmt.Sprintf("cat %v; ", configPath)
+
+	return command
+}
+
+func getConfigPostprocessEnv() []v1.EnvVar {
+	return []v1.EnvVar{
+		{
+			Name: "POD_NAME",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.name",
+				},
+			},
+		},
+		{
+			Name: "POD_NAMESPACE",
+			ValueFrom: &v1.EnvVarSource{
+				FieldRef: &v1.ObjectFieldSelector{
+					FieldPath: "metadata.namespace",
+				},
+			},
+		},
+	}
 }

--- a/pkg/consts/cmd.go
+++ b/pkg/consts/cmd.go
@@ -2,6 +2,7 @@ package consts
 
 const (
 	ConfigMountPoint           = "/config"
+	ConfigTemplateMountPoint   = "/config_template"
 	HTTPSSecretMountPoint      = "/config/https_secret"
 	RPCSecretMountPoint        = "/config/rpc_secret"
 	UIClustersConfigMountPoint = "/opt/app"
@@ -11,16 +12,18 @@ const (
 )
 
 const (
-	YTServerContainerName         = "ytserver"
-	PrepareLocationsContainerName = "prepare-locations"
-	PrepareSecretContainerName    = "prepare-secret"
-	UIContainerName               = "yt-ui"
+	YTServerContainerName          = "ytserver"
+	PostprocessConfigContainerName = "postprocess-config"
+	PrepareLocationsContainerName  = "prepare-locations"
+	PrepareSecretContainerName     = "prepare-secret"
+	UIContainerName                = "yt-ui"
 )
 
 const (
 	ClientConfigFileName = "client.yson"
 
-	InitClusterScriptFileName = "init-cluster.sh"
+	InitClusterScriptFileName       = "init-cluster.sh"
+	PostprocessConfigScriptFileName = "postprocess-config.sh"
 
 	UIClusterConfigFileName = "clusters-config.json"
 	UISecretFileName        = "yt-interface-secret.json"
@@ -28,10 +31,11 @@ const (
 )
 
 const (
-	ConfigVolumeName      = "config"
-	HTTPSSecretVolumeName = "https-secret"
-	RPCSecretVolumeName   = "rpc-secret"
-	InitScriptVolumeName  = "init-script"
-	UIVaultVolumeName     = "vault"
-	UISecretsVolumeName   = "secrets"
+	ConfigTemplateVolumeName = "config-template"
+	ConfigVolumeName         = "config"
+	HTTPSSecretVolumeName    = "https-secret"
+	RPCSecretVolumeName      = "rpc-secret"
+	InitScriptVolumeName     = "init-script"
+	UIVaultVolumeName        = "vault"
+	UISecretsVolumeName      = "secrets"
 )


### PR DESCRIPTION
After this commit config files for server components are not taken as is from config map, but rather treated as templates, which are additionally postprocessed by embedding environment variables like POD_NAME and POD_NAMESPACE.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
