### PR TITLE
Support masters in host network mode.

### DIFF
--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -202,8 +202,7 @@ func (s *serverImpl) rebuildStatefulSet() *appsv1.StatefulSet {
 		NodeSelector: s.instanceSpec.NodeSelector,
 		Tolerations:  s.instanceSpec.Tolerations,
 	}
-	// TODO(zlobober): support host network for masters.
-	if s.ytsaurus.GetResource().Spec.HostNetwork && s.labeller.ComponentName != "Master" {
+	if s.ytsaurus.GetResource().Spec.HostNetwork {
 		statefulSet.Spec.Template.Spec.HostNetwork = true
 		statefulSet.Spec.Template.Spec.DNSPolicy = corev1.DNSClusterFirstWithHostNet
 	}

--- a/pkg/ytconfig/common.go
+++ b/pkg/ytconfig/common.go
@@ -47,6 +47,8 @@ type AddressResolver struct {
 	EnableIPv4 bool `yson:"enable_ipv4"`
 	EnableIPv6 bool `yson:"enable_ipv6"`
 	Retries    *int `yson:"retries,omitempty"`
+
+	LocalhostNameOverride *string `yson:"localhost_name_override,omitempty"`
 }
 
 type PemBlob struct {

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -40,14 +40,20 @@ func NewGenerator(ytsaurus *ytv1.Ytsaurus, clusterDomain string) *Generator {
 	}
 }
 
+func (g *Generator) getMasterPodFqdnSuffix() string {
+	return fmt.Sprintf("%s.%s.svc.%s",
+		g.GetMastersServiceName(),
+		g.ytsaurus.Namespace,
+		g.clusterDomain)
+}
+
 func (g *Generator) getMasterAddresses() []string {
 	names := make([]string, 0, g.ytsaurus.Spec.PrimaryMasters.InstanceCount)
+	masterPodSuffix := g.getMasterPodFqdnSuffix()
 	for _, podName := range g.GetMasterPodNames() {
-		names = append(names, fmt.Sprintf("%s.%s.%s.svc.%s:%d",
+		names = append(names, fmt.Sprintf("%s.%s:%d",
 			podName,
-			g.GetMastersServiceName(),
-			g.ytsaurus.Namespace,
-			g.clusterDomain,
+			masterPodSuffix,
 			consts.MasterRPCPort))
 	}
 	return names
@@ -193,6 +199,19 @@ func (g *Generator) getMasterConfigImpl() (MasterServer, error) {
 	g.fillCommonService(&c.CommonServer)
 	g.fillPrimaryMaster(&c.PrimaryMaster)
 	configureMasterServerCypressManager(g.ytsaurus.Spec, &c.CypressManager)
+
+	if g.ytsaurus.Spec.HostNetwork {
+		// Each master deduces its index within cell by looking up his FQDN in the
+		// list of all master peers. Master peers are specified using their pod addresses,
+		// therefore we must also switch masters from identifying themselves by FQDN addresses
+		// to their pod addresses.
+
+		// POD_NAME is set to pod name through downward API env var and substituted during
+		// config postprocessing.
+		c.AddressResolver.LocalhostNameOverride = ptr.String(
+			fmt.Sprintf("%v.%v", "{POD_NAME}", g.getMasterPodFqdnSuffix()))
+	}
+
 	return c, nil
 }
 


### PR DESCRIPTION
In order to overcome master identification issue (which is done by looking for FQDN in the list of cell peers), we override local FQDN with pod FQDN.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
