### PR TITLE
Fix deadlock in case when UI deployment is manually deleted

### DIFF
--- a/pkg/components/microservice.go
+++ b/pkg/components/microservice.go
@@ -143,8 +143,8 @@ func (m *microserviceImpl) arePodsReady(ctx context.Context) bool {
 }
 
 func (m *microserviceImpl) arePodsRemoved(ctx context.Context) bool {
-	if m.configHelper.NeedInit() || !resources.Exists(m.deployment) || !resources.Exists(m.service) {
-		return false
+	if !resources.Exists(m.deployment) {
+		return true
 	}
 	return m.deployment.ArePodsRemoved(ctx)
 }

--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -148,8 +148,8 @@ func (s *serverImpl) Sync(ctx context.Context) error {
 }
 
 func (s *serverImpl) arePodsRemoved(ctx context.Context) bool {
-	if s.configHelper.NeedInit() || !resources.Exists(s.statefulSet) || !resources.Exists(s.headlessService) {
-		return false
+	if !resources.Exists(s.statefulSet) {
+		return true
 	}
 
 	return s.statefulSet.ArePodsRemoved(ctx)


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

When somebody tries to delete UI deployment while cluster is in UpdateStateWaitingForPodsRemoval, current definition of arePodsRemoved returns false, while logically pods are indeed removed if there is no deployment. It results in a deadlock which prevents UI from reappearing again.

Also, it looks like the same issue may happen with server components, so the similar change is also done for them.
