### PR TITLE
Support dualstack clusters in YQL agent

### DIFF
--- a/pkg/components/yql_agent.go
+++ b/pkg/components/yql_agent.go
@@ -147,10 +147,12 @@ func (yqla *yqlAgent) doSync(ctx context.Context, dry bool) (ComponentStatus, er
 			ss := yqla.server.buildStatefulSet()
 			container := &ss.Spec.Template.Spec.Containers[0]
 			container.EnvFrom = []corev1.EnvFromSource{yqla.secret.GetEnvSource()}
-			if yqla.ytsaurus.GetResource().Spec.UseIPv6 {
+			if yqla.ytsaurus.GetResource().Spec.UseIPv6 && !yqla.ytsaurus.GetResource().Spec.UseIPv4 {
 				container.Env = []corev1.EnvVar{{Name: "YT_FORCE_IPV4", Value: "0"}, {Name: "YT_FORCE_IPV6", Value: "1"}}
-			} else {
+			} else if !yqla.ytsaurus.GetResource().Spec.UseIPv6 && yqla.ytsaurus.GetResource().Spec.UseIPv4 {
 				container.Env = []corev1.EnvVar{{Name: "YT_FORCE_IPV4", Value: "1"}, {Name: "YT_FORCE_IPV6", Value: "0"}}
+			} else {
+				container.Env = []corev1.EnvVar{{Name: "YT_FORCE_IPV4", Value: "0"}, {Name: "YT_FORCE_IPV6", Value: "0"}}
 			}
 			err = yqla.server.Sync(ctx)
 		}


### PR DESCRIPTION
Without this change it is impossible to use YQL agent in clusters where both IPv4 and IPv6 are used simultaneously
(e.g. node domain names resovle in AAAA and kube-dns service domain names resolve in A).

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
