### PR TITLE
Fix master schema ACLs and improve init jobs

### DIFF
--- a/pkg/components/helpers.go
+++ b/pkg/components/helpers.go
@@ -139,11 +139,11 @@ func handleUpdatingClusterState(
 }
 
 func SetPathAcl(path string, acl []yt.ACE) string {
-	aclAsString, err := yson.MarshalFormat(acl, yson.FormatText)
+	formattedAcl, err := yson.MarshalFormat(acl, yson.FormatText)
 	if err != nil {
 		panic(err)
 	}
-	return fmt.Sprintf("/usr/bin/yt set %s/@acl '%s'", path, string(aclAsString))
+	return fmt.Sprintf("/usr/bin/yt set %s/@acl '%s'", path, string(formattedAcl))
 }
 
 func RunIfCondition(condition string, commands ...string) string {

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -211,7 +211,7 @@ func (m *master) initSchemaACLs() string {
 		"tablet_cell", "tablet_action", "tablet_cell_bundle",
 		"user", "group",
 		"rack", "data_center", "cluster_node",
-		"access_control_object", "access_control_object_namespace", "access_control_object_namespace_map"} {
+		"access_control_object_namespace", "access_control_object_namespace_map"} {
 		commands = append(commands, SetPathAcl(fmt.Sprintf("//sys/schemas/%s", objectType), []yt.ACE{
 			userReadACE,
 			adminACE,
@@ -228,8 +228,8 @@ func (m *master) initSchemaACLs() string {
 			adminACE,
 		})))
 
-	// Users can to create pools, pool trees and accounts given the right circumstances and permissions.
-	for _, objectType := range []string{"account", "scheduler_pool", "scheduler_pool_tree"} {
+	// Users can to create pools, pool trees, accounts and access control objects given the right circumstances and permissions.
+	for _, objectType := range []string{"account", "scheduler_pool", "scheduler_pool_tree", "access_control_object"} {
 		commands = append(commands, SetPathAcl(fmt.Sprintf("//sys/schemas/%s", objectType), []yt.ACE{
 			userReadCreateACE,
 			adminACE,

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -228,7 +228,7 @@ func (m *master) initSchemaACLs() string {
 			adminACE,
 		})))
 
-	// Users can to create pools, pool trees, accounts and access control objects given the right circumstances and permissions.
+	// Users can create pools, pool trees, accounts and access control objects given the right circumstances and permissions.
 	for _, objectType := range []string{"account", "scheduler_pool", "scheduler_pool_tree", "access_control_object"} {
 		commands = append(commands, SetPathAcl(fmt.Sprintf("//sys/schemas/%s", objectType), []yt.ACE{
 			userReadCreateACE,

--- a/pkg/components/scheduler.go
+++ b/pkg/components/scheduler.go
@@ -288,7 +288,7 @@ func (s *scheduler) prepareInitOperationArchive() {
 		initJobWithNativeDriverPrologue(),
 		fmt.Sprintf("/usr/bin/init_operation_archive --force --latest --proxy %s",
 			s.cfgen.GetHTTPProxiesServiceAddress(consts.DefaultHTTPProxyRole)),
-		"/usr/bin/yt set //sys/cluster_nodes/@config '{\"%true\" = {job_agent={enable_job_reporter=%true}}}'",
+		SetWithIgnoreExisting("//sys/cluster_nodes/@config", "'{\"%true\" = {job_agent={enable_job_reporter=%true}}}'"),
 	}
 
 	s.initOpArchive.SetInitScript(strings.Join(script, "\n"))


### PR DESCRIPTION
This PR makes several improvements:
* The operator now creates a group for admins (`admins`).
* The operator now sets better ACLs for schemas.
* Master and scheduler init jobs do not overwrite existing dynamic configs anymore.