### PR TITLE
Configure strawberry controller for new UI

### DIFF
--- a/pkg/consts/address.go
+++ b/pkg/consts/address.go
@@ -50,4 +50,6 @@ const (
 	QueueAgentMonitoringPort = 10030
 
 	UIHTTPPort = 80
+
+	StrawberryHTTPAPIPort = 80
 )

--- a/pkg/ytconfig/canondata/TestGetStrawberryControllerConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetStrawberryControllerConfig/test.canondata
@@ -17,4 +17,9 @@
         };
     };
     "http_api_endpoint"=":80";
+    "http_location_aliases"={
+        "http-proxies-lb-test.fake.svc.fake.zone"=[
+            test;
+        ];
+    };
 }

--- a/pkg/ytconfig/chyt.go
+++ b/pkg/ytconfig/chyt.go
@@ -1,6 +1,8 @@
 package ytconfig
 
 import (
+	"fmt"
+
 	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"
 	"go.ytsaurus.tech/yt/go/yson"
 )
@@ -12,10 +14,11 @@ type Strawberry struct {
 }
 
 type StrawberryController struct {
-	LocationProxies []string                 `yson:"location_proxies"`
-	Strawberry      Strawberry               `yson:"strawberry"`
-	Controllers     map[string]yson.RawValue `yson:"controllers"`
-	HTTPAPIEndpoint string                   `yson:"http_api_endpoint"`
+	LocationProxies     []string                 `yson:"location_proxies"`
+	Strawberry          Strawberry               `yson:"strawberry"`
+	Controllers         map[string]yson.RawValue `yson:"controllers"`
+	HTTPAPIEndpoint     string                   `yson:"http_api_endpoint"`
+	HTTPLocationAliases map[string][]string      `yson:"http_location_aliases"`
 }
 
 type ChytInitCluster struct {
@@ -35,7 +38,7 @@ func getStrawberryController() StrawberryController {
 		Controllers: map[string]yson.RawValue{
 			"chyt": yson.RawValue("{address_resolver={enable_ipv4=%true;enable_ipv6=%true;retries=1000}}"),
 		},
-		HTTPAPIEndpoint: ":80",
+		HTTPAPIEndpoint: fmt.Sprintf(":%v", consts.StrawberryHTTPAPIPort),
 	}
 }
 

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -269,8 +269,10 @@ func (g *Generator) GetClusterConnection() ([]byte, error) {
 
 func (g *Generator) GetStrawberryControllerConfig() ([]byte, error) {
 	c := getStrawberryController()
-	c.LocationProxies = []string{
-		g.GetHTTPProxiesAddress(consts.DefaultHTTPProxyRole),
+	proxy := g.GetHTTPProxiesAddress(consts.DefaultHTTPProxyRole)
+	c.LocationProxies = []string{proxy}
+	c.HTTPLocationAliases = map[string][]string{
+		proxy: []string{g.ytsaurus.Name},
 	}
 	return marshallYsonConfig(c)
 }


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

After this changes new `Cliques` UI can be used.
I tested this patch with `ytsaurus/ui:1.15.3` and `ytsaurus/strawberry:0.0.10` images.