### PR TITLE
Operator linear flow

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -478,6 +478,8 @@ type YtsaurusSpec struct {
 
 type ClusterState string
 
+// TODO: I'm not sure if we need so much states
+// I suggest we have: Running, Updating, UpdateBlocked
 const (
 	ClusterStateCreated         ClusterState = "Created"
 	ClusterStateInitializing    ClusterState = "Initializing"

--- a/controllers/component_manager.go
+++ b/controllers/component_manager.go
@@ -17,7 +17,7 @@ type componentsStructured struct {
 	discovery   components.Component2
 	master      components.Component2
 	httpProxies []components.Component2
-	ytClient    components.Component2
+	ytClient    components.YtsaurusClient2
 	dataNodes   []components.Component2
 	// (optional) ui (depends on master)
 	// (optional) rpcproxies (depends on master)

--- a/controllers/conditions.go
+++ b/controllers/conditions.go
@@ -1,0 +1,69 @@
+package controllers
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"
+)
+
+var (
+	SafeModeEnabledCondition = metav1.Condition{
+		Type:    consts.ConditionSafeModeEnabled,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Safe mode was enabled",
+	}
+	TabletCellsSavedCondition = metav1.Condition{
+		Type:    consts.ConditionTabletCellsSaved,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Tablet cells were saved",
+	}
+	TabletCellsRemovedCondition = metav1.Condition{
+		Type:    consts.ConditionTabletCellsRemoved,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Tablet cells were removed",
+	}
+	SnapshotsMonitoringInfoSavedCondition = metav1.Condition{
+		Type:    consts.ConditionSnapshotsMonitoringInfoSaved,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Snapshots monitoring info saved",
+	}
+	SnapshotsBuildingStartedCondition = metav1.Condition{
+		Type:    consts.ConditionSnapshotsBuildingStarted,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Snapshots building started",
+	}
+	MasterSnapshotsBuiltCondition = metav1.Condition{
+		Type:    consts.ConditionSnaphotsSaved,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Master snapshots were built",
+	}
+
+	MasterExitedReadOnlyCondition = metav1.Condition{
+		Type:    consts.ConditionMasterExitedReadOnly,
+		Status:  metav1.ConditionTrue,
+		Reason:  "MasterExitedReadOnly",
+		Message: "Masters exited read-only state",
+	}
+
+	TabletCellsRecoveredCondition = metav1.Condition{
+		Type:    consts.ConditionTabletCellsRecovered,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Tablet cells recovered",
+	}
+	SafeModeDisabledCondition = metav1.Condition{
+		Type:    consts.ConditionSafeModeDisabled,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Safe mode disabled",
+	}
+
+	// TODO: PodsRemovingCondition?
+	// TODO: qt/qa/scheduler conditions
+)

--- a/controllers/envtest.go
+++ b/controllers/envtest.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/require"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -163,6 +164,13 @@ func updateObjectStatus(h *testHelper, newObject client.Object) {
 	k8sCli := h.getK8sClient()
 	err := k8sCli.Status().Update(context.Background(), newObject)
 	require.NoError(h.t, err)
+}
+
+func markJobSucceeded(h *testHelper, key string) {
+	job := &batchv1.Job{}
+	fetchEventually(h, key, job)
+	job.Status.Succeeded = 1
+	updateObjectStatus(h, job)
 }
 
 const (

--- a/controllers/envtest.go
+++ b/controllers/envtest.go
@@ -1,0 +1,202 @@
+package controllers
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
+)
+
+type testHelper struct {
+	t          *testing.T
+	ctx        context.Context
+	cancel     context.CancelFunc
+	k8sTestEnv *envtest.Environment
+	k8sClient  client.Client
+	cfg        *rest.Config
+	namespace  string
+}
+
+func newTestHelper(t *testing.T, namespace string) *testHelper {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		t.Fatal(
+			"KUBEBUILDER_ASSETS needed to be set for this test " +
+				"Something like KUBEBUILDER_ASSETS=`bin/setup-envtest use 1.24.2 -p path` would do." +
+				"Check Makefile for the details.",
+		)
+	}
+	k8sTestEnv := &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			MaxTime: 60 * time.Second,
+		},
+		ControlPlane: envtest.ControlPlane{},
+	}
+
+	testCtx, testCancel := context.WithCancel(context.Background())
+	return &testHelper{
+		t:          t,
+		ctx:        testCtx,
+		cancel:     testCancel,
+		k8sTestEnv: k8sTestEnv,
+		namespace:  namespace,
+	}
+}
+
+func (h *testHelper) start() {
+	t := h.t
+	conf, err := h.k8sTestEnv.Start()
+	require.NoError(t, err)
+	require.NotNil(t, conf)
+	h.cfg = conf
+
+	err = ytv1.AddToScheme(scheme.Scheme)
+	require.NoError(t, err)
+
+	mgr, err := ctrl.NewManager(conf, ctrl.Options{
+		Scheme: scheme.Scheme,
+		// To get rid of macOS' accept incoming network connections popup
+		MetricsBindAddress:     "0",
+		HealthProbeBindAddress: "0",
+	})
+	require.NoError(t, err)
+
+	h.createNamespace()
+
+	err = (&YtsaurusReconciler{
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Recorder: mgr.GetEventRecorderFor("ytsaurus-controller"),
+	}).SetupWithManager(mgr)
+	require.NoError(t, err)
+
+	go func() {
+		err = mgr.Start(h.ctx)
+		require.NoError(t, err)
+	}()
+}
+
+func (h *testHelper) stop() {
+	// Should cancel ctx before Stop
+	// https://github.com/kubernetes-sigs/controller-runtime/issues/1571#issuecomment-945535598
+	h.cancel()
+	err := h.k8sTestEnv.Stop()
+	require.NoError(h.t, err)
+}
+
+func (h *testHelper) getK8sClient() client.Client {
+	if h.k8sClient == nil {
+		k8sCli, err := client.New(h.cfg, client.Options{Scheme: scheme.Scheme})
+		require.NoError(h.t, err)
+		h.k8sClient = k8sCli
+	}
+	return h.k8sClient
+}
+
+func (h *testHelper) getObjectKey(name string) client.ObjectKey {
+	return client.ObjectKey{Name: name, Namespace: h.namespace}
+}
+
+func (h *testHelper) getObjectMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name, Namespace: h.namespace}
+}
+
+func (h *testHelper) createNamespace() {
+	c := h.getK8sClient()
+	ns := corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: h.namespace,
+		},
+	}
+	err := c.Create(context.Background(), &ns)
+	require.NoError(h.t, err)
+}
+
+// helpers
+func getObject(h *testHelper, key string, emptyObject client.Object) {
+	k8sCli := h.getK8sClient()
+	err := k8sCli.Get(context.Background(), h.getObjectKey(key), emptyObject)
+	require.NoError(h.t, err)
+}
+func deployObject(h *testHelper, object client.Object) {
+	k8sCli := h.getK8sClient()
+	err := k8sCli.Create(context.Background(), object)
+	require.NoError(h.t, err)
+}
+func updateObject(h *testHelper, emptyObject, newObject client.Object) {
+	k8sCli := h.getK8sClient()
+
+	//key := client.ObjectKey{Name: newObject.GetName(), Namespace: newObject.GetNamespace()}
+	getObject(h, newObject.GetName(), emptyObject)
+
+	newObject.SetResourceVersion(emptyObject.GetResourceVersion())
+	err := k8sCli.Update(context.Background(), newObject)
+	require.NoError(h.t, err)
+}
+
+const (
+	eventuallyWaitTime = 10 * time.Second
+	eventuallyTickTime = 500 * time.Millisecond
+)
+
+func fetchEventually(h *testHelper, key string, obj client.Object) {
+	h.t.Logf("start waiting for %v to be found", key)
+	fetchAndCheckEventually(
+		h,
+		key,
+		obj,
+		func(obj client.Object) bool {
+			return true
+		})
+}
+func fetchAndCheckEventually(h *testHelper, key string, obj client.Object, condition func(obj client.Object) bool) {
+	h.t.Logf("start waiting for %v to be found with condition", key)
+	k8sCli := h.getK8sClient()
+	eventually(
+		h,
+		func() bool {
+			err := k8sCli.Get(context.Background(), h.getObjectKey(key), obj)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					h.t.Logf("object %v not found.", key)
+					return false
+				}
+				require.NoError(h.t, err)
+			}
+			return condition(obj)
+		},
+	)
+}
+func eventually(h *testHelper, condition func() bool) {
+	h.t.Logf("start waiting for condition")
+	waitTime := eventuallyWaitTime
+	// Useful when debugging test.
+	waitTimeFromEnv := os.Getenv("TEST_EVENTUALLY_WAIT_TIME")
+	if waitTimeFromEnv != "" {
+		var err error
+		waitTime, err = time.ParseDuration(waitTimeFromEnv)
+		if err != nil {
+			h.t.Fatalf("failed to parse TEST_EVENTUALLY_WAIT_TIME=%s", waitTimeFromEnv)
+		}
+	}
+	require.Eventually(
+		h.t,
+		condition,
+		waitTime,
+		eventuallyTickTime,
+	)
+}

--- a/controllers/step.go
+++ b/controllers/step.go
@@ -1,0 +1,82 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/ytsaurus/yt-k8s-operator/pkg/components"
+)
+
+type baseStep struct {
+	name         string
+	runCondition func() bool
+}
+type dummyStep struct {
+	name string
+}
+type componentStep struct {
+	baseStep
+	component components.Component2
+}
+type actionStep struct {
+	baseStep
+	action    func(context.Context) error
+	doneCheck func(context.Context) (bool, error)
+}
+
+func (s *baseStep) GetName() string {
+	return s.name
+}
+func (s *baseStep) ShouldRun() bool {
+	if s.runCondition == nil {
+		return true
+	}
+	return !s.runCondition()
+}
+
+func newComponentStep(component components.Component2) *componentStep {
+	return &componentStep{component: component}
+}
+func (s *componentStep) WithRunCondition(condition func() bool) *componentStep {
+	s.runCondition = condition
+	return s
+}
+func (s *componentStep) Done(ctx context.Context) (bool, error) {
+	status, err := s.component.Status2(ctx)
+	return status.IsReady(), err
+}
+func (s *componentStep) Run(ctx context.Context) error {
+	return s.component.Sync(ctx)
+}
+
+func newActionStep(
+	action func(context.Context) error,
+	doneCheck func(context.Context) (bool, error),
+) *actionStep {
+	return &actionStep{
+		action:    action,
+		doneCheck: doneCheck,
+	}
+}
+func (s *actionStep) WithRunCondition(condition func() bool) *actionStep {
+	s.runCondition = condition
+	return s
+}
+func (s *actionStep) Done(ctx context.Context) (bool, error) {
+	return s.doneCheck(ctx)
+}
+func (s *actionStep) Run(ctx context.Context) error {
+	return s.action(ctx)
+}
+
+func newDummyStep() *dummyStep {
+	return &dummyStep{}
+}
+func (s *dummyStep) Skip() bool {
+	return true
+}
+func (s *dummyStep) Done(ctx context.Context) (bool, error) {
+	return true, nil
+}
+func (s *dummyStep) Do(_ context.Context) error {
+	return nil
+}

--- a/controllers/step.go
+++ b/controllers/step.go
@@ -46,10 +46,18 @@ func (s *componentStep) WithRunCondition(condition func() bool) *componentStep {
 	return s
 }
 func (s *componentStep) Done(ctx context.Context) (bool, error) {
+	err := s.component.Fetch(ctx)
+	if err != nil {
+		return false, err
+	}
 	status, err := s.component.Status2(ctx)
 	return status.IsReady(), err
 }
 func (s *componentStep) Run(ctx context.Context) error {
+	err := s.component.Fetch(ctx)
+	if err != nil {
+		return err
+	}
 	return s.component.Sync2(ctx)
 }
 

--- a/controllers/step.go
+++ b/controllers/step.go
@@ -8,7 +8,7 @@ import (
 
 type baseStep struct {
 	name         string
-	runCondition func() bool
+	runCondition func(context.Context) (bool, string, error)
 }
 type dummyStep struct {
 	name string
@@ -26,11 +26,12 @@ type actionStep struct {
 func (s *baseStep) GetName() string {
 	return s.name
 }
-func (s *baseStep) ShouldRun() bool {
+func (s *baseStep) ShouldRun(ctx context.Context) (bool, string, error) {
 	if s.runCondition == nil {
-		return true
+		return true, "no run condition is set", nil
 	}
-	return !s.runCondition()
+	shouldRun, comment, err := s.runCondition(ctx)
+	return shouldRun, comment, err
 }
 
 func newComponentStep(component components.Component2) *componentStep {
@@ -41,7 +42,7 @@ func newComponentStep(component components.Component2) *componentStep {
 		component: component,
 	}
 }
-func (s *componentStep) WithRunCondition(condition func() bool) *componentStep {
+func (s *componentStep) WithRunCondition(condition func(context.Context) (bool, string, error)) *componentStep {
 	s.runCondition = condition
 	return s
 }
@@ -81,7 +82,7 @@ func newActionStep(
 		doneCheck: doneCheck,
 	}
 }
-func (s *actionStep) WithRunCondition(condition func() bool) *actionStep {
+func (s *actionStep) WithRunCondition(condition func(ctx context.Context) (bool, string, error)) *actionStep {
 	s.runCondition = condition
 	return s
 }

--- a/controllers/step.go
+++ b/controllers/step.go
@@ -53,6 +53,13 @@ func (s *componentStep) Done(ctx context.Context) (bool, error) {
 	status, err := s.component.Status2(ctx)
 	return status.IsReady(), err
 }
+func (s *componentStep) Status(ctx context.Context) (components.ComponentStatus, error) {
+	err := s.component.Fetch(ctx)
+	if err != nil {
+		return components.ComponentStatus{}, err
+	}
+	return s.component.Status2(ctx)
+}
 func (s *componentStep) Run(ctx context.Context) error {
 	err := s.component.Fetch(ctx)
 	if err != nil {
@@ -80,6 +87,16 @@ func (s *actionStep) WithRunCondition(condition func() bool) *actionStep {
 }
 func (s *actionStep) Done(ctx context.Context) (bool, error) {
 	return s.doneCheck(ctx)
+}
+func (s *actionStep) Status(ctx context.Context) (components.ComponentStatus, error) {
+	done, err := s.Done(ctx)
+	if err != nil {
+		return components.ComponentStatus{}, err
+	}
+	if done {
+		return components.SimpleStatus(components.SyncStatusReady), nil
+	}
+	return components.SimpleStatus(components.SyncStatusNeedLocalUpdate), nil
 }
 func (s *actionStep) Run(ctx context.Context) error {
 	return s.action(ctx)

--- a/controllers/step.go
+++ b/controllers/step.go
@@ -1,117 +1,31 @@
 package controllers
 
-import (
-	"context"
+type StepSyncStatus string
 
-	"github.com/ytsaurus/yt-k8s-operator/pkg/components"
+const (
+	// StepSyncStatusDone means that step is done.
+	StepSyncStatusDone StepSyncStatus = "Done"
+	// StepSyncStatusSkip means that step must be skipped.
+	StepSyncStatusSkip StepSyncStatus = "Skip"
+	// StepSyncStatusUpdating means that step execution is in progress,
+	// but currently nothing can be done by operator but wait.
+	StepSyncStatusUpdating StepSyncStatus = "Updating"
+	// StepSyncStatusBlocked means that step can't be executed for some reason,
+	// and it is possible that human needed to proceed.
+	StepSyncStatusBlocked StepSyncStatus = "Blocked"
+	// StepSyncStatusNeedRun means that step should be executed.
+	StepSyncStatusNeedRun StepSyncStatus = "NeedRun"
 )
 
+type StepStatus struct {
+	SyncStatus StepSyncStatus
+	Message    string
+}
+
 type baseStep struct {
-	name         string
-	runCondition func(context.Context) (bool, string, error)
-}
-type dummyStep struct {
 	name string
-}
-type componentStep struct {
-	baseStep
-	component components.Component2
-}
-type actionStep struct {
-	baseStep
-	action    func(context.Context) error
-	doneCheck func(context.Context) (bool, error)
 }
 
 func (s *baseStep) GetName() string {
 	return s.name
-}
-func (s *baseStep) ShouldRun(ctx context.Context) (bool, string, error) {
-	if s.runCondition == nil {
-		return true, "no run condition is set", nil
-	}
-	shouldRun, comment, err := s.runCondition(ctx)
-	return shouldRun, comment, err
-}
-
-func newComponentStep(component components.Component2) *componentStep {
-	return &componentStep{
-		baseStep: baseStep{
-			name: component.GetName(),
-		},
-		component: component,
-	}
-}
-func (s *componentStep) WithRunCondition(condition func(context.Context) (bool, string, error)) *componentStep {
-	s.runCondition = condition
-	return s
-}
-func (s *componentStep) Done(ctx context.Context) (bool, error) {
-	err := s.component.Fetch(ctx)
-	if err != nil {
-		return false, err
-	}
-	status, err := s.component.Status2(ctx)
-	return status.IsReady(), err
-}
-func (s *componentStep) Status(ctx context.Context) (components.ComponentStatus, error) {
-	err := s.component.Fetch(ctx)
-	if err != nil {
-		return components.ComponentStatus{}, err
-	}
-	return s.component.Status2(ctx)
-}
-func (s *componentStep) Run(ctx context.Context) error {
-	err := s.component.Fetch(ctx)
-	if err != nil {
-		return err
-	}
-	return s.component.Sync2(ctx)
-}
-
-func newActionStep(
-	name string,
-	action func(context.Context) error,
-	doneCheck func(context.Context) (bool, error),
-) *actionStep {
-	return &actionStep{
-		baseStep: baseStep{
-			name: name,
-		},
-		action:    action,
-		doneCheck: doneCheck,
-	}
-}
-func (s *actionStep) WithRunCondition(condition func(ctx context.Context) (bool, string, error)) *actionStep {
-	s.runCondition = condition
-	return s
-}
-func (s *actionStep) Done(ctx context.Context) (bool, error) {
-	return s.doneCheck(ctx)
-}
-func (s *actionStep) Status(ctx context.Context) (components.ComponentStatus, error) {
-	done, err := s.Done(ctx)
-	if err != nil {
-		return components.ComponentStatus{}, err
-	}
-	if done {
-		return components.SimpleStatus(components.SyncStatusReady), nil
-	}
-	return components.SimpleStatus(components.SyncStatusNeedLocalUpdate), nil
-}
-func (s *actionStep) Run(ctx context.Context) error {
-	return s.action(ctx)
-}
-
-func newDummyStep() *dummyStep {
-	return &dummyStep{}
-}
-func (s *dummyStep) Skip() bool {
-	return true
-}
-func (s *dummyStep) Done(ctx context.Context) (bool, error) {
-	return true, nil
-}
-func (s *dummyStep) Do(_ context.Context) error {
-	return nil
 }

--- a/controllers/step.go
+++ b/controllers/step.go
@@ -34,7 +34,12 @@ func (s *baseStep) ShouldRun() bool {
 }
 
 func newComponentStep(component components.Component2) *componentStep {
-	return &componentStep{component: component}
+	return &componentStep{
+		baseStep: baseStep{
+			name: component.GetName(),
+		},
+		component: component,
+	}
 }
 func (s *componentStep) WithRunCondition(condition func() bool) *componentStep {
 	s.runCondition = condition
@@ -45,14 +50,18 @@ func (s *componentStep) Done(ctx context.Context) (bool, error) {
 	return status.IsReady(), err
 }
 func (s *componentStep) Run(ctx context.Context) error {
-	return s.component.Sync(ctx)
+	return s.component.Sync2(ctx)
 }
 
 func newActionStep(
+	name string,
 	action func(context.Context) error,
 	doneCheck func(context.Context) (bool, error),
 ) *actionStep {
 	return &actionStep{
+		baseStep: baseStep{
+			name: name,
+		},
 		action:    action,
 		doneCheck: doneCheck,
 	}

--- a/controllers/step.go
+++ b/controllers/step.go
@@ -1,6 +1,7 @@
 package controllers
 
 type StepSyncStatus string
+type StepName string
 
 const (
 	// StepSyncStatusDone means that step is done.
@@ -23,9 +24,31 @@ type StepStatus struct {
 }
 
 type baseStep struct {
-	name string
+	name StepName
 }
 
-func (s *baseStep) GetName() string {
+func (s *baseStep) GetName() StepName {
 	return s.name
+}
+
+type executionStats struct {
+	statuses map[StepName]StepStatus
+}
+
+func newExecutionStats() executionStats {
+	return executionStats{
+		statuses: make(map[StepName]StepStatus),
+	}
+}
+
+func (s *executionStats) Collect(name StepName, status StepStatus) {
+	s.statuses[name] = status
+}
+
+func (s *executionStats) isSkipped(name StepName) bool {
+	status, wasExecuted := s.statuses[name]
+	if !wasExecuted {
+		return false
+	}
+	return status.SyncStatus == StepSyncStatusSkip
 }

--- a/controllers/step_action.go
+++ b/controllers/step_action.go
@@ -27,7 +27,7 @@ func newActionStep(
 	}
 }
 
-func newActionStepWithCondition(
+func newActionStepWithDoneCondition(
 	name StepName,
 	action func(context.Context, *ytsaurusState) error,
 	statusCheck func(context.Context, *ytsaurusState) (StepStatus, error),

--- a/controllers/step_action.go
+++ b/controllers/step_action.go
@@ -7,13 +7,13 @@ import (
 type actionStep struct {
 	baseStep
 	action      func(context.Context) error
-	statusCheck func(context.Context, executionStats) (StepStatus, error)
+	statusCheck func(context.Context, *ytsaurusState) (StepStatus, error)
 }
 
 func newActionStep(
 	name StepName,
 	action func(context.Context) error,
-	statusCheck func(context.Context, executionStats) (StepStatus, error),
+	statusCheck func(context.Context, *ytsaurusState) (StepStatus, error),
 ) *actionStep {
 	return &actionStep{
 		baseStep: baseStep{
@@ -23,8 +23,8 @@ func newActionStep(
 		statusCheck: statusCheck,
 	}
 }
-func (s *actionStep) Status(ctx context.Context, execStats executionStats) (StepStatus, error) {
-	return s.statusCheck(ctx, execStats)
+func (s *actionStep) Status(ctx context.Context, state *ytsaurusState) (StepStatus, error) {
+	return s.statusCheck(ctx, state)
 }
 func (s *actionStep) Run(ctx context.Context) error {
 	return s.action(ctx)

--- a/controllers/step_action.go
+++ b/controllers/step_action.go
@@ -1,0 +1,31 @@
+package controllers
+
+import (
+	"context"
+)
+
+type actionStep struct {
+	baseStep
+	action      func(context.Context) error
+	statusCheck func(context.Context) (StepStatus, error)
+}
+
+func newActionStep(
+	name string,
+	action func(context.Context) error,
+	statusCheck func(context.Context) (StepStatus, error),
+) *actionStep {
+	return &actionStep{
+		baseStep: baseStep{
+			name: name,
+		},
+		action:      action,
+		statusCheck: statusCheck,
+	}
+}
+func (s *actionStep) Status(ctx context.Context) (StepStatus, error) {
+	return s.statusCheck(ctx)
+}
+func (s *actionStep) Run(ctx context.Context) error {
+	return s.action(ctx)
+}

--- a/controllers/step_action.go
+++ b/controllers/step_action.go
@@ -7,13 +7,13 @@ import (
 type actionStep struct {
 	baseStep
 	action      func(context.Context) error
-	statusCheck func(context.Context) (StepStatus, error)
+	statusCheck func(context.Context, executionStats) (StepStatus, error)
 }
 
 func newActionStep(
-	name string,
+	name StepName,
 	action func(context.Context) error,
-	statusCheck func(context.Context) (StepStatus, error),
+	statusCheck func(context.Context, executionStats) (StepStatus, error),
 ) *actionStep {
 	return &actionStep{
 		baseStep: baseStep{
@@ -23,8 +23,8 @@ func newActionStep(
 		statusCheck: statusCheck,
 	}
 }
-func (s *actionStep) Status(ctx context.Context) (StepStatus, error) {
-	return s.statusCheck(ctx)
+func (s *actionStep) Status(ctx context.Context, execStats executionStats) (StepStatus, error) {
+	return s.statusCheck(ctx, execStats)
 }
 func (s *actionStep) Run(ctx context.Context) error {
 	return s.action(ctx)

--- a/controllers/step_action.go
+++ b/controllers/step_action.go
@@ -6,14 +6,16 @@ import (
 
 type actionStep struct {
 	baseStep
-	action      func(context.Context) error
+	action      func(context.Context, *ytsaurusState) error
 	statusCheck func(context.Context, *ytsaurusState) (StepStatus, error)
+	doneCheck   func(context.Context, *ytsaurusState) (bool, error)
 }
 
 func newActionStep(
 	name StepName,
-	action func(context.Context) error,
+	action func(context.Context, *ytsaurusState) error,
 	statusCheck func(context.Context, *ytsaurusState) (StepStatus, error),
+	doneFunc func(context.Context, *ytsaurusState) (bool, error),
 ) *actionStep {
 	return &actionStep{
 		baseStep: baseStep{
@@ -21,11 +23,43 @@ func newActionStep(
 		},
 		action:      action,
 		statusCheck: statusCheck,
+		doneCheck:   doneFunc,
 	}
 }
-func (s *actionStep) Status(ctx context.Context, state *ytsaurusState) (StepStatus, error) {
-	return s.statusCheck(ctx, state)
+
+func newActionStepWithCondition(
+	name StepName,
+	action func(context.Context, *ytsaurusState) error,
+	statusCheck func(context.Context, *ytsaurusState) (StepStatus, error),
+	doneCondition string,
+) *actionStep {
+	return newActionStep(
+		name,
+		action,
+		statusCheck,
+		func(ctx context.Context, state *ytsaurusState) (bool, error) {
+			return state.isUpdateStatusConditionTrue(doneCondition), nil
+		},
+	)
 }
-func (s *actionStep) Run(ctx context.Context) error {
-	return s.action(ctx)
+
+func (s *actionStep) Status(ctx context.Context, state *ytsaurusState) (StepStatus, error) {
+	status, err := s.statusCheck(ctx, state)
+	if err != nil {
+		return StepStatus{}, err
+	}
+	if status.SyncStatus != StepSyncStatusNeedRun {
+		return status, nil
+	}
+	done, err := s.doneCheck(ctx, state)
+	if err != nil {
+		return StepStatus{}, err
+	}
+	if done {
+		return StepStatus{StepSyncStatusDone, ""}, nil
+	}
+	return status, nil
+}
+func (s *actionStep) Run(ctx context.Context, state *ytsaurusState) error {
+	return s.action(ctx, state)
 }

--- a/controllers/step_component.go
+++ b/controllers/step_component.go
@@ -1,0 +1,47 @@
+package controllers
+
+import (
+	"context"
+
+	"github.com/ytsaurus/yt-k8s-operator/pkg/components"
+)
+
+type componentStep struct {
+	baseStep
+	component components.Component2
+}
+
+func newComponentStep(component components.Component2) *componentStep {
+	return &componentStep{
+		baseStep: baseStep{
+			name: component.GetName(),
+		},
+		component: component,
+	}
+}
+func (s *componentStep) Status(ctx context.Context) (StepStatus, error) {
+	componentStatus, err := s.component.Status2(ctx)
+	if err != nil {
+		return StepStatus{}, err
+	}
+	stepSyncStatus := map[components.SyncStatus]StepSyncStatus{
+		// NB: no StepSyncStatusSkip here: component step is not meant to be skipped.
+		components.SyncStatusReady:           StepSyncStatusDone,
+		components.SyncStatusPending:         StepSyncStatusUpdating,
+		components.SyncStatusUpdating:        StepSyncStatusUpdating,
+		components.SyncStatusBlocked:         StepSyncStatusBlocked,
+		components.SyncStatusNeedFullUpdate:  StepSyncStatusNeedRun,
+		components.SyncStatusNeedLocalUpdate: StepSyncStatusNeedRun,
+	}[componentStatus.SyncStatus]
+	return StepStatus{
+		SyncStatus: stepSyncStatus,
+		Message:    componentStatus.Message,
+	}, nil
+}
+func (s *componentStep) Run(ctx context.Context) error {
+	err := s.component.Fetch(ctx)
+	if err != nil {
+		return err
+	}
+	return s.component.Sync2(ctx)
+}

--- a/controllers/step_component.go
+++ b/controllers/step_component.go
@@ -14,12 +14,12 @@ type componentStep struct {
 func newComponentStep(component components.Component2) *componentStep {
 	return &componentStep{
 		baseStep: baseStep{
-			name: component.GetName(),
+			name: StepName(component.GetName()),
 		},
 		component: component,
 	}
 }
-func (s *componentStep) Status(ctx context.Context) (StepStatus, error) {
+func (s *componentStep) Status(ctx context.Context, _ executionStats) (StepStatus, error) {
 	componentStatus, err := s.component.Status2(ctx)
 	if err != nil {
 		return StepStatus{}, err

--- a/controllers/step_component.go
+++ b/controllers/step_component.go
@@ -19,7 +19,7 @@ func newComponentStep(component components.Component2) *componentStep {
 		component: component,
 	}
 }
-func (s *componentStep) Status(ctx context.Context, _ executionStats) (StepStatus, error) {
+func (s *componentStep) Status(ctx context.Context, _ *ytsaurusState) (StepStatus, error) {
 	componentStatus, err := s.component.Status2(ctx)
 	if err != nil {
 		return StepStatus{}, err

--- a/controllers/step_component.go
+++ b/controllers/step_component.go
@@ -38,7 +38,7 @@ func (s *componentStep) Status(ctx context.Context, _ *ytsaurusState) (StepStatu
 		Message:    componentStatus.Message,
 	}, nil
 }
-func (s *componentStep) Run(ctx context.Context) error {
+func (s *componentStep) Run(ctx context.Context, _ *ytsaurusState) error {
 	err := s.component.Fetch(ctx)
 	if err != nil {
 		return err

--- a/controllers/step_dummy.go
+++ b/controllers/step_dummy.go
@@ -1,0 +1,9 @@
+package controllers
+
+type dummyStep struct {
+	name string
+}
+
+func newDummyStep() *dummyStep {
+	return &dummyStep{}
+}

--- a/controllers/sync.go
+++ b/controllers/sync.go
@@ -253,7 +253,7 @@ func (r *YtsaurusReconciler) Sync(ctx context.Context, resource *ytv1.Ytsaurus) 
 
 	ytsaurus := apiProxy.NewYtsaurus(resource, r.Client, r.Recorder, r.Scheme)
 	componentManager, err := NewComponentManager(ytsaurus)
-	err = componentManager.FetchAll(ctx)
+	err = componentManager.CollectStatuses(ctx)
 	if err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}

--- a/controllers/sync.go
+++ b/controllers/sync.go
@@ -252,7 +252,8 @@ func (r *YtsaurusReconciler) Sync(ctx context.Context, resource *ytv1.Ytsaurus) 
 	}
 
 	ytsaurus := apiProxy.NewYtsaurus(resource, r.Client, r.Recorder, r.Scheme)
-	componentManager, err := NewComponentManager(ctx, ytsaurus)
+	componentManager, err := NewComponentManager(ytsaurus)
+	err = componentManager.FetchAll(ctx)
 	if err != nil {
 		return ctrl.Result{Requeue: true}, err
 	}

--- a/controllers/ytsaurus_controller.go
+++ b/controllers/ytsaurus_controller.go
@@ -18,6 +18,8 @@ package controllers
 
 import (
 	"context"
+	"os"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -62,6 +64,10 @@ func (r *YtsaurusReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	}
 	logger.V(1).Info("found Ytsaurus cluster")
 
+	// temporary
+	if os.Getenv("ENABLE_NEW_FLOW") == "true" {
+		return r.SyncNew(ctx, &ytsaurus)
+	}
 	return r.Sync(ctx, &ytsaurus)
 }
 

--- a/controllers/ytsaurus_inmemory.go
+++ b/controllers/ytsaurus_inmemory.go
@@ -3,8 +3,10 @@ package controllers
 // TODO(l0kix2): this code has a lot of copypaste, needs small refactoring
 
 import (
+	"io"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 
 	"go.ytsaurus.tech/yt/go/yson"
@@ -15,10 +17,17 @@ type YtsaurusInMemory struct {
 	mx      sync.RWMutex
 	cypress map[string]any
 }
+type valueWithGenericAttrs struct {
+	Attrs map[string]any `yson:",attrs"`
+	Value any            `yson:",value"`
+}
 
 func NewYtsaurusInMemory() *YtsaurusInMemory {
 	return &YtsaurusInMemory{
-		cypress: make(map[string]any),
+		cypress: map[string]any{
+			"//sys/tablet_cells/":       map[string]any{},
+			"//sys/tablet_cell_bundles": map[string]any{},
+		},
 	}
 }
 
@@ -26,6 +35,8 @@ func (y *YtsaurusInMemory) Start(port int) error {
 	http.HandleFunc("/api/v4/get", y.getHandler)
 	http.HandleFunc("/api/v4/list", y.listHandler)
 	http.HandleFunc("/api/v4/exists", y.existsHandler)
+	http.HandleFunc("/api/v4/set", y.setHandler)
+	http.HandleFunc("/api/v4/remove", y.removeHandler)
 	return http.ListenAndServe("localhost:"+strconv.Itoa(port), nil)
 }
 
@@ -84,7 +95,8 @@ func (y *YtsaurusInMemory) getHandler(w http.ResponseWriter, r *http.Request) {
 func (y *YtsaurusInMemory) listHandler(w http.ResponseWriter, r *http.Request) {
 	paramsSerialized := r.Header.Get("X-Yt-Parameters")
 	type Params struct {
-		Path string `yson:"path"`
+		Path       string   `yson:"path"`
+		Attributes []string `yson:"attributes"`
 	}
 	params := Params{}
 	var err error
@@ -95,7 +107,7 @@ func (y *YtsaurusInMemory) listHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	values, ok := y.List(params.Path)
+	values, ok := y.List(params.Path, params.Attributes)
 	if !ok {
 		w.WriteHeader(http.StatusBadRequest)
 		// {"code":500,"message":"Attribute \"nonexistent\" is not found","attributes":{"host":"localhost","pid":74,"tid":6385775732996512218,"fid":18446446043579299186,"datetime":"2024-02-14T11:40:14.500934Z","trace_id":"9cf2de84-837d5527-b486f4d5-98a700cf","span_id":11858309240037149274,"path":"//sys/@nonexistent"}}
@@ -120,8 +132,8 @@ func (y *YtsaurusInMemory) listHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	var serialized []byte
 	if r.Header.Get("X-Yt-Output-Format") == "yson" {
-		wrapedValue := map[string][]string{"value": values}
-		serialized, err = yson.Marshal(wrapedValue)
+		wrappedValue := map[string][]valueWithGenericAttrs{"value": values}
+		serialized, err = yson.Marshal(wrappedValue)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -165,11 +177,51 @@ func (y *YtsaurusInMemory) existsHandler(w http.ResponseWriter, r *http.Request)
 		}
 	}
 }
+func (y *YtsaurusInMemory) setHandler(w http.ResponseWriter, r *http.Request) {
+	paramsSerialized := r.Header.Get("X-Yt-Parameters")
+	type Params struct {
+		Path string `yson:"path"`
+	}
+	params := Params{}
+	var err error
+	var value any
+	if r.Header.Get("X-Yt-Input-Format") == "yson" {
+		err = yson.Unmarshal([]byte(paramsSerialized), &params)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 
-func (y *YtsaurusInMemory) Set(path string, value any) {
-	y.mx.Lock()
-	defer y.mx.Unlock()
-	y.cypress[path] = value
+		var bodyRaw []byte
+		bodyRaw, err = io.ReadAll(r.Body)
+		err = yson.Unmarshal(bodyRaw, &value)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	y.Set(params.Path, value)
+	w.WriteHeader(http.StatusOK)
+}
+func (y *YtsaurusInMemory) removeHandler(w http.ResponseWriter, r *http.Request) {
+	type Params struct {
+		Path string `yson:"path"`
+	}
+	params := Params{}
+	var err error
+	if r.Header.Get("X-Yt-Input-Format") == "yson" {
+		var bodyRaw []byte
+		bodyRaw, err = io.ReadAll(r.Body)
+		err = yson.Unmarshal(bodyRaw, &params)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
+	y.Remove(params.Path)
+	w.WriteHeader(http.StatusOK)
 }
 
 func (y *YtsaurusInMemory) Get(path string) (any, bool) {
@@ -178,22 +230,72 @@ func (y *YtsaurusInMemory) Get(path string) (any, bool) {
 	value, ok := y.cypress[path]
 	return value, ok
 }
-func (y *YtsaurusInMemory) List(path string) ([]string, bool) {
+func (y *YtsaurusInMemory) List(path string, attributes []string) ([]valueWithGenericAttrs, bool) {
+	// value=[<health=good;>sys;<health=good;>default;<health=good;>sequoia;];
+	// {
+	//value=[<health=good;>sys;<health=good;>default;<health=good;>sequoia;];}
 	y.mx.RLock()
 	defer y.mx.RUnlock()
 	value, ok := y.cypress[path]
 	if !ok {
 		return nil, false
 	}
-	var keys []string
+	var result []valueWithGenericAttrs
 	for key := range value.(map[string]any) {
-		keys = append(keys, key)
+		item := valueWithGenericAttrs{Value: key}
+		item.Attrs = make(map[string]any)
+		for _, attr := range attributes {
+			attrVal := y.cypress[path+"/"+key+"/@"+attr]
+			item.Attrs[attr] = attrVal
+		}
+		result = append(result, item)
 	}
-	return keys, ok
+	return result, ok
 }
 func (y *YtsaurusInMemory) Exists(path string) bool {
 	y.mx.RLock()
 	defer y.mx.RUnlock()
 	_, ok := y.cypress[path]
 	return ok
+}
+func (y *YtsaurusInMemory) Set(path string, value any) {
+	y.mx.Lock()
+	defer y.mx.Unlock()
+	y.cypress[path] = value
+	//y.updateCounters()
+}
+func (y *YtsaurusInMemory) Remove(path string) {
+	y.mx.Lock()
+	defer y.mx.Unlock()
+	delete(y.cypress, path)
+
+	lastSepIdx := strings.LastIndex(path, "/")
+	parentPath := path[:lastSepIdx]
+	base := path[lastSepIdx+1:]
+
+	parent, exists := y.cypress[parentPath]
+	if !exists {
+		// todo: less dummy implementation must consistently maintain the tree
+		panic("no " + parentPath + " for " + path)
+	}
+	delete(parent.(map[string]any), base)
+	//y.updateCounters()
+}
+func (y *YtsaurusInMemory) updateCounters() {
+	bundleCounters := map[string]int{}
+	cellsMap, exists := y.cypress["//sys/tablet_cells"]
+	if !exists {
+		cellsMap = make(map[string]any)
+		y.cypress["//sys/tablet_cells"] = cellsMap
+	}
+	for cellId := range cellsMap.(map[string]any) {
+		bundle, ok := y.cypress["//sys/tablet_cells/"+cellId+"/@tablet_cell_bundle"]
+		if !ok {
+			panic("no @tablet_cell_bundle is set for " + cellId)
+		}
+		bundleCounters[bundle.(string)] += 1
+	}
+	for bundle, count := range bundleCounters {
+		y.cypress["//sys/tablet_cell_bundles/"+bundle+"/@tablet_cell_count"] = count
+	}
 }

--- a/controllers/ytsaurus_inmemory.go
+++ b/controllers/ytsaurus_inmemory.go
@@ -1,5 +1,7 @@
 package controllers
 
+// TODO(l0kix2): this code has a lot of copypaste, needs small refactoring
+
 import (
 	"net/http"
 	"strconv"

--- a/controllers/ytsaurus_inmemory.go
+++ b/controllers/ytsaurus_inmemory.go
@@ -1,0 +1,197 @@
+package controllers
+
+import (
+	"net/http"
+	"strconv"
+	"sync"
+
+	"go.ytsaurus.tech/yt/go/yson"
+	"go.ytsaurus.tech/yt/go/yterrors"
+)
+
+type YtsaurusInMemory struct {
+	mx      sync.RWMutex
+	cypress map[string]any
+}
+
+func NewYtsaurusInMemory() *YtsaurusInMemory {
+	return &YtsaurusInMemory{
+		cypress: make(map[string]any),
+	}
+}
+
+func (y *YtsaurusInMemory) Start(port int) error {
+	http.HandleFunc("/api/v4/get", y.getHandler)
+	http.HandleFunc("/api/v4/list", y.listHandler)
+	http.HandleFunc("/api/v4/exists", y.existsHandler)
+	return http.ListenAndServe("localhost:"+strconv.Itoa(port), nil)
+}
+
+func (y *YtsaurusInMemory) getHandler(w http.ResponseWriter, r *http.Request) {
+	paramsSerialized := r.Header.Get("X-Yt-Parameters")
+	type Params struct {
+		Path string `yson:"path"`
+	}
+	params := Params{}
+	var err error
+	if r.Header.Get("X-Yt-Input-Format") == "yson" {
+		err = yson.Unmarshal([]byte(paramsSerialized), &params)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	value, ok := y.Get(params.Path)
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		// {"code":500,"message":"Attribute \"nonexistent\" is not found","attributes":{"host":"localhost","pid":74,"tid":6385775732996512218,"fid":18446446043579299186,"datetime":"2024-02-14T11:40:14.500934Z","trace_id":"9cf2de84-837d5527-b486f4d5-98a700cf","span_id":11858309240037149274,"path":"//sys/@nonexistent"}}
+		ytErr := yterrors.Error{
+			Code:    500,
+			Message: "Error resolving path " + params.Path,
+		}
+		var serializedErr []byte
+		serializedErr, err = yson.Marshal(ytErr)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, err = w.Write(serializedErr)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	var serialized []byte
+	if r.Header.Get("X-Yt-Output-Format") == "yson" {
+		wrappedValue := map[string]any{"value": value}
+		serialized, err = yson.Marshal(wrappedValue)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, err = w.Write(serialized)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+func (y *YtsaurusInMemory) listHandler(w http.ResponseWriter, r *http.Request) {
+	paramsSerialized := r.Header.Get("X-Yt-Parameters")
+	type Params struct {
+		Path string `yson:"path"`
+	}
+	params := Params{}
+	var err error
+	if r.Header.Get("X-Yt-Input-Format") == "yson" {
+		err = yson.Unmarshal([]byte(paramsSerialized), &params)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	values, ok := y.List(params.Path)
+	if !ok {
+		w.WriteHeader(http.StatusBadRequest)
+		// {"code":500,"message":"Attribute \"nonexistent\" is not found","attributes":{"host":"localhost","pid":74,"tid":6385775732996512218,"fid":18446446043579299186,"datetime":"2024-02-14T11:40:14.500934Z","trace_id":"9cf2de84-837d5527-b486f4d5-98a700cf","span_id":11858309240037149274,"path":"//sys/@nonexistent"}}
+		ytErr := yterrors.Error{
+			Code:    500,
+			Message: "Error resolving path " + params.Path,
+		}
+		var serializedErr []byte
+		serializedErr, err = yson.Marshal(ytErr)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, err = w.Write(serializedErr)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+	var serialized []byte
+	if r.Header.Get("X-Yt-Output-Format") == "yson" {
+		wrapedValue := map[string][]string{"value": values}
+		serialized, err = yson.Marshal(wrapedValue)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, err = w.Write(serialized)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+func (y *YtsaurusInMemory) existsHandler(w http.ResponseWriter, r *http.Request) {
+	paramsSerialized := r.Header.Get("X-Yt-Parameters")
+	type Params struct {
+		Path string `yson:"path"`
+	}
+	params := Params{}
+	var err error
+	if r.Header.Get("X-Yt-Input-Format") == "yson" {
+		err = yson.Unmarshal([]byte(paramsSerialized), &params)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+	exists := y.Exists(params.Path)
+
+	w.WriteHeader(http.StatusOK)
+	var serialized []byte
+	if r.Header.Get("X-Yt-Output-Format") == "yson" {
+		wrappedValue := map[string]bool{"value": exists}
+		serialized, err = yson.Marshal(wrappedValue)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		_, err = w.Write(serialized)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+}
+
+func (y *YtsaurusInMemory) Set(path string, value any) {
+	y.mx.Lock()
+	defer y.mx.Unlock()
+	y.cypress[path] = value
+}
+
+func (y *YtsaurusInMemory) Get(path string) (any, bool) {
+	y.mx.RLock()
+	defer y.mx.RUnlock()
+	value, ok := y.cypress[path]
+	return value, ok
+}
+func (y *YtsaurusInMemory) List(path string) ([]string, bool) {
+	y.mx.RLock()
+	defer y.mx.RUnlock()
+	value, ok := y.cypress[path]
+	if !ok {
+		return nil, false
+	}
+	var keys []string
+	for key := range value.(map[string]any) {
+		keys = append(keys, key)
+	}
+	return keys, ok
+}
+func (y *YtsaurusInMemory) Exists(path string) bool {
+	y.mx.RLock()
+	defer y.mx.RUnlock()
+	_, ok := y.cypress[path]
+	return ok
+}

--- a/controllers/ytsaurus_inmemory.go
+++ b/controllers/ytsaurus_inmemory.go
@@ -231,9 +231,6 @@ func (y *YtsaurusInMemory) Get(path string) (any, bool) {
 	return value, ok
 }
 func (y *YtsaurusInMemory) List(path string, attributes []string) ([]valueWithGenericAttrs, bool) {
-	// value=[<health=good;>sys;<health=good;>default;<health=good;>sequoia;];
-	// {
-	//value=[<health=good;>sys;<health=good;>default;<health=good;>sequoia;];}
 	y.mx.RLock()
 	defer y.mx.RUnlock()
 	value, ok := y.cypress[path]

--- a/controllers/ytsaurus_inmemory_test.go
+++ b/controllers/ytsaurus_inmemory_test.go
@@ -1,0 +1,42 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.ytsaurus.tech/yt/go/ypath"
+	"go.ytsaurus.tech/yt/go/yt"
+	"go.ytsaurus.tech/yt/go/yt/ythttp"
+)
+
+func TestTempGoClient(t *testing.T) {
+	ctx := context.Background()
+
+	ytClient, err := ythttp.NewClient(&yt.Config{
+		Proxy:                 "localhost:8000",
+		Token:                 "password",
+		DisableProxyDiscovery: true,
+	})
+	require.NoError(t, err)
+
+	//var isReadOnly bool
+	//err = ytClient.GetNode(context.Background(), ypath.Path("//sys/@hydra_read_only"), isReadOnly, nil)
+	//require.False(t, isReadOnly)
+
+	//var tabletCells []string
+	//err = ytClient.ListNode(
+	//	context.Background(),
+	//	ypath.Path("//sys/tablet_cellsx"),
+	//	&tabletCells,
+	//	nil,
+	//)
+	//require.NoError(t, err)
+	//var smth any
+	//err = ytClient.GetNode(context.Background(), ypath.Path("//sys/@nonexistent"), smth, nil)
+	//require.Nil(t, smth)
+
+	ok, err := ytClient.NodeExists(ctx, ypath.Path("//sys/@enable_safe_mode"), nil)
+	require.NoError(t, err)
+	require.True(t, ok)
+}

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -40,11 +40,18 @@ func TestYtsaurusFromScratch(t *testing.T) {
 			"ms-0.masters."+namespace+".svc.cluster.local:9010",
 		)
 	}
+	fetchAndCheckConfigMapContainsEventually(
+		h,
+		"yt-data-node-"+dndsNameOne+"-config",
+		"ytserver-data-node.yson",
+		"ms-0.masters."+namespace+".svc.cluster.local:9010",
+	)
 
 	for _, stsName := range []string{
 		"ds",
 		"ms",
 		"hp",
+		"dnd-" + dndsNameOne,
 	} {
 		fetchAndCheckEventually(
 			h,
@@ -113,7 +120,15 @@ func buildMinimalYtsaurus(h *testHelper, name string) ytv1.Ytsaurus {
 			},
 			DataNodes: []ytv1.DataNodesSpec{
 				{
-					InstanceSpec:     ytv1.InstanceSpec{InstanceCount: 5},
+					InstanceSpec: ytv1.InstanceSpec{
+						InstanceCount: 5,
+						Locations: []ytv1.LocationSpec{
+							{
+								LocationType: "ChunkStore",
+								Path:         "/yt/node-data/chunk-store",
+							},
+						},
+					},
 					ClusterNodesSpec: ytv1.ClusterNodesSpec{},
 					Name:             dndsNameOne,
 				},

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -112,6 +112,9 @@ func TestYtsaurusUpdateMasterImage(t *testing.T) {
 
 	// emulate tablet cells recovered
 	//h.ytsaurusInMemory.Set("//sys/tablet_cell_bundles", map[string]any{"sys": nil})
+	h.ytsaurusInMemory.Set("//sys/tablet_cells", map[string]any{
+		"1-602-2bc-955ed415": nil,
+	})
 	//h.ytsaurusInMemory.Set("//sys/tablet_cells/1-602-2bc-955ed415/@tablet_cell_bundle", "sys")
 
 	fetchAndCheckEventually(
@@ -165,16 +168,7 @@ func TestYtsaurusUpdateMasterImage(t *testing.T) {
 	ytsaurusResource.Spec.EnableFullUpdate = true
 	updateObject(h, &ytv1.Ytsaurus{}, &ytsaurusResource)
 
-	fetchAndCheckEventually(
-		h,
-		ytsaurusName,
-		&ytv1.Ytsaurus{},
-		func(obj client.Object) bool {
-			state := obj.(*ytv1.Ytsaurus).Status.State
-			return state == ytv1.ClusterStateUpdating
-		},
-	)
-
+	t.Log("[ Wait for YTsaurus Running status ]")
 	fetchAndCheckEventually(
 		h,
 		ytsaurusName,

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -180,7 +180,6 @@ func TestYtsaurusUpdateMasterImage(t *testing.T) {
 		"cell_id":   "1",
 		"addresses": masterAddressesList,
 	})
-	// AreMasterSnapshotsBuilt
 	var masterMonitoringPaths []string
 	for _, ms := range masterAddressesList {
 		path := "//sys/cluster_masters/" + ms + "/orchid/monitoring/hydra"
@@ -200,7 +199,7 @@ func TestYtsaurusUpdateMasterImage(t *testing.T) {
 		},
 	)
 
-	// emulate startBuildMasterSnapshots executed
+	t.Log("[ Emulate startBuildMasterSnapshots executed ]")
 	for _, path := range masterMonitoringPaths {
 		h.ytsaurusInMemory.Set(path, map[string]any{
 			"read_only":               true,

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -75,10 +75,6 @@ func TestYtsaurusFromScratch(t *testing.T) {
 		},
 	)
 
-	// emulate master read only is done
-	markJobSucceeded(h, "yt-master-init-job-exit-read-only")
-	h.ytsaurusInMemory.Set("//sys/@hydra_read_only", true)
-
 	// emulate tablet cells recovered
 	h.ytsaurusInMemory.Set("//sys/tablet_cells", map[string]any{
 		"1-602-2bc-955ed415": nil,

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
@@ -27,7 +28,7 @@ func TestYtsaurusFromScratch(t *testing.T) {
 
 	h.ytsaurusInMemory.Set("//sys/@hydra_read_only", false)
 
-	ytsaurusResource := buildMinimalYtsaurus(h, ytsaurusName)
+	ytsaurusResource := buildMinimalYtsaurus(namespace, ytsaurusName)
 	deployObject(h, &ytsaurusResource)
 
 	// emulate master init job succeeded
@@ -100,15 +101,14 @@ func TestYtsaurusUpdateMasterImage(t *testing.T) {
 	defer h.stop()
 
 	h.ytsaurusInMemory.Set("//sys/@hydra_read_only", false)
-	ytsaurusResource := buildMinimalYtsaurus(h, ytsaurusName)
+	ytsaurusResource := buildMinimalYtsaurus(namespace, ytsaurusName)
 	deployObject(h, &ytsaurusResource)
 
 	// emulate master init job succeeded
 	markJobSucceeded(h, "yt-master-init-job-default")
 
 	// emulate master read only is done
-	markJobSucceeded(h, "yt-master-init-job-exit-read-only")
-	h.ytsaurusInMemory.Set("//sys/@hydra_read_only", true)
+	//markJobSucceeded(h, "yt-master-init-job-exit-read-only")
 
 	// emulate tablet cells recovered
 	h.ytsaurusInMemory.Set("//sys/tablet_cell_bundles", map[string]any{"sys": nil})
@@ -186,9 +186,9 @@ func TestYtsaurusUpdateMasterImage(t *testing.T) {
 	)
 }
 
-func buildMinimalYtsaurus(h *testHelper, name string) ytv1.Ytsaurus {
+func buildMinimalYtsaurus(namespace, name string) ytv1.Ytsaurus {
 	remoteYtsaurus := ytv1.Ytsaurus{
-		ObjectMeta: h.getObjectMeta(name),
+		ObjectMeta: v1.ObjectMeta{Namespace: namespace, Name: name},
 		Spec: ytv1.YtsaurusSpec{
 			CoreImage:        testYtsaurusImage,
 			IsManaged:        true,

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -76,11 +76,11 @@ func TestYtsaurusFromScratch(t *testing.T) {
 		},
 	)
 
-	// emulate tablet cells recovered
-	h.ytsaurusInMemory.Set("//sys/tablet_cells", map[string]any{
-		"1-602-2bc-955ed415": nil,
-	})
-	h.ytsaurusInMemory.Set("//sys/tablet_cells/1-602-2bc-955ed415/@tablet_cell_bundle", "sys")
+	//// emulate tablet cells recovered
+	//h.ytsaurusInMemory.Set("//sys/tablet_cells", map[string]any{
+	//	"1-602-2bc-955ed415": nil,
+	//})
+	//h.ytsaurusInMemory.Set("//sys/tablet_cells/1-602-2bc-955ed415/@tablet_cell_bundle", "sys")
 
 	fetchAndCheckEventually(
 		h,
@@ -100,7 +100,7 @@ func TestYtsaurusUpdateMasterImage(t *testing.T) {
 	h.start()
 	defer h.stop()
 
-	h.ytsaurusInMemory.Set("//sys/@hydra_read_only", false)
+	//h.ytsaurusInMemory.Set("//sys/@hydra_read_only", false)
 	ytsaurusResource := buildMinimalYtsaurus(namespace, ytsaurusName)
 	deployObject(h, &ytsaurusResource)
 
@@ -111,8 +111,8 @@ func TestYtsaurusUpdateMasterImage(t *testing.T) {
 	//markJobSucceeded(h, "yt-master-init-job-exit-read-only")
 
 	// emulate tablet cells recovered
-	h.ytsaurusInMemory.Set("//sys/tablet_cell_bundles", map[string]any{"sys": nil})
-	h.ytsaurusInMemory.Set("//sys/tablet_cells/1-602-2bc-955ed415/@tablet_cell_bundle", "sys")
+	//h.ytsaurusInMemory.Set("//sys/tablet_cell_bundles", map[string]any{"sys": nil})
+	//h.ytsaurusInMemory.Set("//sys/tablet_cells/1-602-2bc-955ed415/@tablet_cell_bundle", "sys")
 
 	fetchAndCheckEventually(
 		h,
@@ -141,7 +141,7 @@ func TestYtsaurusUpdateMasterImage(t *testing.T) {
 	)
 
 	// Making full update possible.
-	h.ytsaurusInMemory.Set("//sys/tablet_cell_bundles/sys/@health", "good")
+	//h.ytsaurusInMemory.Set("//sys/tablet_cell_bundles/sys/@health", "good")
 	h.ytsaurusInMemory.Set("//sys/lost_vital_chunks/@count", 0)
 	h.ytsaurusInMemory.Set("//sys/quorum_missing_chunks/@count", 0)
 	h.ytsaurusInMemory.Set(

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -56,6 +56,16 @@ func TestYtsaurusFromScratch(t *testing.T) {
 
 	fetchAndCheckEventually(
 		h,
+		"yt-client-secret",
+		&corev1.Secret{},
+		func(obj client.Object) bool {
+			secret := obj.(*corev1.Secret)
+			return len(secret.Data["YT_TOKEN"]) != 0
+		},
+	)
+
+	fetchAndCheckEventually(
+		h,
 		ytsaurusName,
 		&ytv1.Ytsaurus{},
 		func(obj client.Object) bool {

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -28,30 +28,32 @@ func TestYtsaurusFromScratch(t *testing.T) {
 	remoteYtsaurusSpec := buildMinimalYtsaurus(h, ytsaurusName)
 	deployObject(h, &remoteYtsaurusSpec)
 
-	fetchAndCheckEventually(
-		h,
+	for _, compName := range []string{
+		"discovery",
+		"master",
+		"http-proxy",
+	} {
+		fetchAndCheckConfigMapContainsEventually(
+			h,
+			"yt-"+compName+"-config",
+			"ytserver-"+compName+".yson",
+			"ms-0.masters."+namespace+".svc.cluster.local:9010",
+		)
+	}
+
+	for _, stsName := range []string{
 		"ds",
-		&appsv1.StatefulSet{},
-		func(obj client.Object) bool { return true },
-	)
-	fetchAndCheckConfigMapContainsEventually(
-		h,
-		"yt-discovery-config",
-		"ytserver-discovery.yson",
-		"ms-0.masters."+namespace+".svc.cluster.local:9010",
-	)
-	fetchAndCheckEventually(
-		h,
 		"ms",
-		&appsv1.StatefulSet{},
-		func(obj client.Object) bool { return true },
-	)
-	fetchAndCheckConfigMapContainsEventually(
-		h,
-		"yt-master-config",
-		"ytserver-master.yson",
-		"ds-0.discovery."+namespace+".svc.cluster.local:9020",
-	)
+		"hp",
+	} {
+		fetchAndCheckEventually(
+			h,
+			stsName,
+			&appsv1.StatefulSet{},
+			func(obj client.Object) bool { return true },
+		)
+	}
+
 	fetchAndCheckEventually(
 		h,
 		ytsaurusName,

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -1,0 +1,75 @@
+package controllers
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
+)
+
+const (
+	ytsaurusName      = "testsaurus"
+	testYtsaurusImage = "test-ytsaurus-image"
+	dndsNameOne       = "dn-1"
+)
+
+func TestYtsaurusFromScratch(t *testing.T) {
+	require.NoError(t, os.Setenv("ENABLE_NEW_FLOW", "true"))
+	h := newTestHelper(t, "ytsaurus-from-scratch")
+	h.start()
+	defer h.stop()
+
+	remoteYtsaurusSpec := buildMinimalYtsaurus(h, ytsaurusName)
+	deployObject(h, &remoteYtsaurusSpec)
+
+	fetchAndCheckEventually(
+		h,
+		ytsaurusName,
+		&ytv1.Ytsaurus{},
+		func(obj client.Object) bool {
+			state := obj.(*ytv1.Ytsaurus).Status.State
+			return state == ytv1.ClusterStateRunning
+		},
+	)
+}
+
+func buildMinimalYtsaurus(h *testHelper, name string) ytv1.Ytsaurus {
+	remoteYtsaurus := ytv1.Ytsaurus{
+		ObjectMeta: h.getObjectMeta(name),
+		Spec: ytv1.YtsaurusSpec{
+			CoreImage:        testYtsaurusImage,
+			IsManaged:        true,
+			EnableFullUpdate: false,
+
+			Discovery: ytv1.DiscoverySpec{
+				InstanceSpec: ytv1.InstanceSpec{
+					InstanceCount: 3,
+				},
+			},
+			PrimaryMasters: ytv1.MastersSpec{
+				InstanceSpec: ytv1.InstanceSpec{
+					InstanceCount: 3,
+				},
+				CellTag: 1,
+			},
+			HTTPProxies: []ytv1.HTTPProxiesSpec{
+				{
+					InstanceSpec: ytv1.InstanceSpec{InstanceCount: 3},
+					ServiceType:  v1.ServiceTypeNodePort,
+				},
+			},
+			DataNodes: []ytv1.DataNodesSpec{
+				{
+					InstanceSpec:     ytv1.InstanceSpec{InstanceCount: 5},
+					ClusterNodesSpec: ytv1.ClusterNodesSpec{},
+					Name:             dndsNameOne,
+				},
+			},
+		},
+	}
+	return remoteYtsaurus
+}

--- a/controllers/ytsaurus_state.go
+++ b/controllers/ytsaurus_state.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/components"
@@ -54,4 +55,7 @@ func (s *ytsaurusState) isStatusConditionTrue(conditionType string) bool {
 }
 func (s *ytsaurusState) isStatusConditionFalse(conditionType string) bool {
 	return meta.IsStatusConditionFalse(s.ytsaurusStatus.Conditions, conditionType)
+}
+func (s *ytsaurusState) SetStatusCondition(condition metav1.Condition) {
+	meta.SetStatusCondition(&s.ytsaurusStatus.Conditions, condition)
 }

--- a/controllers/ytsaurus_state.go
+++ b/controllers/ytsaurus_state.go
@@ -59,3 +59,7 @@ func (s *ytsaurusState) isStatusConditionFalse(conditionType string) bool {
 func (s *ytsaurusState) SetStatusCondition(condition metav1.Condition) {
 	meta.SetStatusCondition(&s.ytsaurusStatus.Conditions, condition)
 }
+
+func (s *ytsaurusState) SetUpdateStatusCondition(condition metav1.Condition) {
+	meta.SetStatusCondition(&s.ytsaurusStatus.UpdateStatus.Conditions, condition)
+}

--- a/controllers/ytsaurus_state.go
+++ b/controllers/ytsaurus_state.go
@@ -1,0 +1,57 @@
+package controllers
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
+	"github.com/ytsaurus/yt-k8s-operator/pkg/components"
+)
+
+type ytsaurusState struct {
+	comps          componentsStore
+	ytsaurusStatus ytv1.YtsaurusStatus
+	statuses       map[string]components.ComponentStatus
+}
+
+func newYtsaurusState(
+	comps componentsStore,
+	ytsaurusStatus ytv1.YtsaurusStatus,
+
+) *ytsaurusState {
+	return &ytsaurusState{
+		comps:          comps,
+		ytsaurusStatus: ytsaurusStatus,
+		statuses:       make(map[string]components.ComponentStatus),
+	}
+}
+
+func (s *ytsaurusState) Build(ctx context.Context) error {
+	for _, comp := range s.comps.all2() {
+		err := comp.Fetch(ctx)
+		name := comp.GetName()
+		if err != nil {
+			return fmt.Errorf("failed to fetch component %s: %w", name, err)
+		}
+		status, err := comp.Status2(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to fetch component's status %s: %w", name, err)
+		}
+		s.statuses[name] = status
+	}
+	return nil
+}
+
+func (s *ytsaurusState) getMasterStatus() components.ComponentStatus {
+	// TODO: constants
+	return s.statuses["Master"]
+}
+
+func (s *ytsaurusState) isStatusConditionTrue(conditionType string) bool {
+	return meta.IsStatusConditionTrue(s.ytsaurusStatus.Conditions, conditionType)
+}
+func (s *ytsaurusState) isStatusConditionFalse(conditionType string) bool {
+	return meta.IsStatusConditionFalse(s.ytsaurusStatus.Conditions, conditionType)
+}

--- a/controllers/ytsaurus_state.go
+++ b/controllers/ytsaurus_state.go
@@ -13,13 +13,13 @@ import (
 
 type ytsaurusState struct {
 	comps          componentsStore
-	ytsaurusStatus ytv1.YtsaurusStatus
+	ytsaurusStatus *ytv1.YtsaurusStatus
 	statuses       map[string]components.ComponentStatus
 }
 
 func newYtsaurusState(
 	comps componentsStore,
-	ytsaurusStatus ytv1.YtsaurusStatus,
+	ytsaurusStatus *ytv1.YtsaurusStatus,
 
 ) *ytsaurusState {
 	return &ytsaurusState{
@@ -53,13 +53,15 @@ func (s *ytsaurusState) getMasterStatus() components.ComponentStatus {
 func (s *ytsaurusState) isStatusConditionTrue(conditionType string) bool {
 	return meta.IsStatusConditionTrue(s.ytsaurusStatus.Conditions, conditionType)
 }
+func (s *ytsaurusState) isUpdateStatusConditionTrue(conditionType string) bool {
+	return meta.IsStatusConditionTrue(s.ytsaurusStatus.UpdateStatus.Conditions, conditionType)
+}
 func (s *ytsaurusState) isStatusConditionFalse(conditionType string) bool {
 	return meta.IsStatusConditionFalse(s.ytsaurusStatus.Conditions, conditionType)
 }
 func (s *ytsaurusState) SetStatusCondition(condition metav1.Condition) {
 	meta.SetStatusCondition(&s.ytsaurusStatus.Conditions, condition)
 }
-
 func (s *ytsaurusState) SetUpdateStatusCondition(condition metav1.Condition) {
 	meta.SetStatusCondition(&s.ytsaurusStatus.UpdateStatus.Conditions, condition)
 }

--- a/controllers/ytsaurus_steps.go
+++ b/controllers/ytsaurus_steps.go
@@ -36,10 +36,10 @@ func NewYtsaurus(ctx context.Context, ytsaurusProxy *apiProxy.Ytsaurus) (*Ytsaur
 		httpProxiesSteps = append(httpProxiesSteps, newComponentStep(hp))
 	}
 	ytsaurusClientStep := newComponentStep(comps.ytClient)
-	//var dataNodesSteps []Step
-	//for _, dn := range comps.dataNodes {
-	//	dataNodesSteps = append(dataNodesSteps, newComponentStep(dn))
-	//}
+	var dataNodesSteps []Step
+	for _, dn := range comps.dataNodes {
+		dataNodesSteps = append(dataNodesSteps, newComponentStep(dn))
+	}
 
 	// TODO: not lose enable fullUpdate — it should become blocked status
 	steps := concat(
@@ -51,7 +51,7 @@ func NewYtsaurus(ctx context.Context, ytsaurusProxy *apiProxy.Ytsaurus) (*Ytsaur
 		masterStep,
 		httpProxiesSteps,
 		ytsaurusClientStep,
-		//dataNodesSteps,
+		dataNodesSteps,
 		// (optional) ui (depends on master)
 		// (optional) rpcproxies (depends on master)
 		// (optional) tcpproxies (depends on master)

--- a/controllers/ytsaurus_steps.go
+++ b/controllers/ytsaurus_steps.go
@@ -1,0 +1,271 @@
+package controllers
+
+import (
+	"context"
+	"reflect"
+
+	apiProxy "github.com/ytsaurus/yt-k8s-operator/pkg/apiproxy"
+	"github.com/ytsaurus/yt-k8s-operator/pkg/components"
+)
+
+type Step interface {
+	GetName() string
+	ShouldRun() bool
+	Run(ctx context.Context) error
+	Done(ctx context.Context) (bool, error)
+}
+
+type Ytsaurus struct {
+	steps []Step
+}
+
+func NewYtsaurus(ctx context.Context, ytsaurus *apiProxy.Ytsaurus) (*Ytsaurus, error) {
+	componentManager, err := NewComponentManager(ctx, ytsaurus)
+	if err != nil {
+		return nil, err
+	}
+	comps := componentManager.allStructured
+
+	discoveryStep := newComponentStep(comps.discovery)
+	masterStep := newComponentStep(comps.master)
+	httpProxiesSteps := make([]Step, len(comps.httpProxies))
+	for _, hp := range comps.httpProxies {
+		httpProxiesSteps = append(httpProxiesSteps, newComponentStep(hp))
+	}
+	ytsaurusClientStep := newComponentStep(comps.ytClient)
+	dataNodesSteps := make([]Step, len(comps.dataNodes))
+	for _, dn := range comps.dataNodes {
+		dataNodesSteps = append(dataNodesSteps, newComponentStep(dn))
+	}
+
+	steps := concat(
+		enableSafeMode(),
+		saveTabletCells(),
+		removeTabletCells(),
+		buildMasterSnapshots(),
+		discoveryStep,
+		masterStep,
+		httpProxiesSteps,
+		ytsaurusClientStep,
+		dataNodesSteps,
+		// (optional) ui (depends on master)
+		// (optional) rpcproxies (depends on master)
+		// (optional) tcpproxies (depends on master)
+		// (optional) execnodes (depends on master)
+		// (optional) tabletnodes (depends on master, yt client)
+		// (optional) scheduler (depends on master, exec nodes, tablet nodes)
+		// (optional) controller agents (depends on master)
+		// (optional) querytrackers (depends on yt client and tablet nodes)
+		// (optional) queueagents (depend on y cli, master, tablet nodes)
+		// (optional) yqlagents (depend on master)
+		// (optional) strawberry (depend on master, scheduler, data nodes)
+		masterExitReadOnly(),
+		recoverTableCells(),
+		updateOpArchive(),
+		updateQTState(),
+		disableSafeMode(),
+	)
+	return &Ytsaurus{
+		steps: steps,
+	}, nil
+}
+
+func (c *Ytsaurus) Fetch(_ context.Context) error {
+	return nil
+}
+
+func (c *Ytsaurus) Status(ctx context.Context) (components.ComponentStatus, error) {
+	for _, step := range c.steps {
+		if step.ShouldRun() {
+			continue
+		}
+		done, err := step.Done(ctx)
+		if err != nil {
+			return components.ComponentStatus{}, err
+		}
+		if done {
+			continue
+		}
+
+		return components.ComponentStatus{
+			SyncStatus: components.SyncStatusPending,
+			Message:    step.GetName() + " is not done",
+		}, nil
+	}
+	return components.ComponentStatus{
+		SyncStatus: components.SyncStatusReady,
+	}, nil
+}
+
+func (c *Ytsaurus) Sync(ctx context.Context) error {
+	for _, step := range c.steps {
+		if step.ShouldRun() {
+			continue
+		}
+		done, err := step.Done(ctx)
+		if err != nil {
+			return err
+		}
+		if done {
+			continue
+		}
+		return step.Run(ctx)
+	}
+	return nil
+}
+
+func enableSafeMode() Step {
+	action := func(context.Context) error {
+		// use ytclient code
+		// where we will get ytclient — I suppose it is some common thing
+		// we don't exactly call it component maybe?
+		// or for simplicity now we can put this method in Ytsaurus component
+		return nil
+	}
+	doneCheck := func(context.Context) (bool, error) {
+		// check @enable_safe_mode is set
+		return false, nil
+	}
+	runCondition := func() bool {
+		// if master status is syncNeedRecreate
+		//    return true
+		// if data node status is syncNeedRecreate
+		//    return true
+		// if tablet node status is syncNeedRecreate
+		//    return true
+		// if check for update possibility stuff
+		//    return true
+		return false
+	}
+	return newActionStep(action, doneCheck).WithRunCondition(runCondition)
+}
+func saveTabletCells() Step {
+	action := func(context.Context) error {
+		// use ytclient code
+		// ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles = tabletCellBundles
+		return nil
+	}
+	doneCheck := func(context.Context) (bool, error) {
+		// check ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles not empty?
+		return false, nil
+	}
+	runCondition := func() bool {
+		// reuse some code from maybeEnableSafeModeStep about master/data/tablet statuses
+		return false
+	}
+	return newActionStep(action, doneCheck).WithRunCondition(runCondition)
+}
+func removeTabletCells() Step {
+	action := func(context.Context) error {
+		// use ytclient code
+		// yc.ytClient.RemoveNode
+		return nil
+	}
+	doneCheck := func(context.Context) (bool, error) {
+		// check //sys/tablet_cells is empty?
+		// like in UpdateStateWaitingForTabletCellsRemoved
+		return false, nil
+	}
+	runCondition := func() bool {
+		// reuse some code from maybeEnableSafeModeStep about master/data/tablet statuses
+		return false
+	}
+	return newActionStep(action, doneCheck).WithRunCondition(runCondition)
+}
+func buildMasterSnapshots() Step {
+	action := func(context.Context) error {
+		// use ytclient code
+		// yc.ytClient.RemoveNode
+		return nil
+	}
+	doneCheck := func(context.Context) (bool, error) {
+		// check //sys/tablet_cells is empty?
+		// like in UpdateStateWaitingForTabletCellsRemoved
+		return false, nil
+	}
+	runCondition := func() bool {
+		// reuse some code from maybeEnableSafeModeStep about master/data/tablet statuses
+		return false
+	}
+	return newActionStep(action, doneCheck).WithRunCondition(runCondition)
+}
+
+// maybe it shouldn't be inside master at all
+func masterExitReadOnly() Step {
+	action := func(context.Context) error {
+		// runJob
+		return nil
+	}
+	doneCheck := func(context.Context) (bool, error) {
+		// is read only check
+		return false, nil
+	}
+	return newActionStep(action, doneCheck)
+}
+func recoverTableCells() Step {
+	action := func(context.Context) error {
+		// helpers.CreateTabletCells
+		// delete status
+		return nil
+	}
+	doneCheck := func(context.Context) (bool, error) {
+		// check TabletCellBundles not empty &&  TabletCellBundles != //sys/tablet_cell_bundles ??
+		return false, nil
+	}
+	return newActionStep(action, doneCheck)
+}
+
+// maybe prepare is needed also?
+func updateOpArchive() Step {
+	action := func(context.Context) error {
+		// maybe we can use scheduler component here
+		// run job
+		return nil
+	}
+	doneCheck := func(context.Context) (bool, error) {
+		// maybe some //sys/cluster_nodes/@config value?
+		// check script and understand how to check if archive is inited
+		return false, nil
+	}
+	return newActionStep(action, doneCheck)
+}
+func updateQTState() Step {
+	action := func(context.Context) error {
+		// maybe we can use queryTracker component here
+		// run job
+		return nil
+	}
+	doneCheck := func(context.Context) (bool, error) {
+		// maybe some //sys/cluster_nodes/@config value?
+		// check /usr/bin/init_query_tracker_state script and understand how to check if qt state is set
+		return false, nil
+	}
+	return newActionStep(action, doneCheck)
+}
+func disableSafeMode() Step {
+	action := func(context.Context) error {
+		// use ytclient code
+		return nil
+	}
+	doneCheck := func(context.Context) (bool, error) {
+		// check @enable_safe_mode is false
+		return false, nil
+	}
+	return newActionStep(action, doneCheck)
+}
+
+func concat(items ...interface{}) []Step {
+	var result []Step
+	for _, item := range items {
+		if reflect.TypeOf(item).Kind() == reflect.Slice {
+			result = append(result, item.([]Step)...)
+			continue
+		}
+		if value, ok := item.(Step); ok {
+			result = append(result, value)
+			continue
+		}
+		panic("concat expect only Step or []Step in arguments")
+	}
+	return result
+}

--- a/controllers/ytsaurus_steps.go
+++ b/controllers/ytsaurus_steps.go
@@ -46,7 +46,6 @@ func NewYtsaurusSteps(ytsaurusProxy *apiProxy.Ytsaurus) (*YtsaurusSteps, error) 
 		dataNodesSteps = append(dataNodesSteps, newComponentStep(dn))
 	}
 
-	//ytsaurusResource := ytsaurusProxy.GetResource()
 	steps := concat(
 		enableSafeMode(yc, comps.master),
 		saveTabletCells(yc, comps.master),

--- a/controllers/ytsaurus_steps.go
+++ b/controllers/ytsaurus_steps.go
@@ -39,7 +39,7 @@ func NewYtsaurusSteps(ytsaurusProxy *apiProxy.Ytsaurus) (*YtsaurusSteps, error) 
 	for _, hp := range comps.httpProxies {
 		httpProxiesSteps = append(httpProxiesSteps, newComponentStep(hp))
 	}
-	yc := comps.ytClient.(components.YtsaurusClient)
+	yc := comps.ytClient.(components.YtsaurusClient2)
 	ytsaurusClientStep := newComponentStep(comps.ytClient)
 	var dataNodesSteps []Step
 	for _, dn := range comps.dataNodes {
@@ -119,7 +119,7 @@ func (s *YtsaurusSteps) Sync(ctx context.Context) (ytv1.ClusterState, error) {
 	return ytv1.ClusterStateRunning, nil
 }
 
-func getFullUpdateCondition(yc components.YtsaurusClient, master components.Component2) func(context.Context) (bool, string, error) {
+func getFullUpdateCondition(yc components.YtsaurusClient2, master components.Component2) func(context.Context) (bool, string, error) {
 	return func(ctx context.Context) (bool, string, error) {
 		if master.Status(ctx).SyncStatus != components.SyncStatusNeedFullUpdate {
 			return false, "master doesn't need recreating", nil
@@ -140,7 +140,7 @@ func getFullUpdateCondition(yc components.YtsaurusClient, master components.Comp
 	}
 }
 
-func enableSafeMode(yc components.YtsaurusClient, master components.Component2) Step {
+func enableSafeMode(yc components.YtsaurusClient2, master components.Component2) Step {
 	action := func(ctx context.Context) error {
 		return yc.EnableSafeMode(ctx)
 	}
@@ -150,7 +150,7 @@ func enableSafeMode(yc components.YtsaurusClient, master components.Component2) 
 	runCondition := getFullUpdateCondition(yc, master)
 	return newActionStep("enableSafeMode", action, doneCheck).WithRunCondition(runCondition)
 }
-func saveTabletCells(yc components.YtsaurusClient, master components.Component2) Step {
+func saveTabletCells(yc components.YtsaurusClient2, master components.Component2) Step {
 	action := func(ctx context.Context) error {
 		return yc.SaveTableCellsAndUpdateState(ctx)
 	}
@@ -160,7 +160,7 @@ func saveTabletCells(yc components.YtsaurusClient, master components.Component2)
 	runCondition := getFullUpdateCondition(yc, master)
 	return newActionStep("saveTabletCells", action, doneCheck).WithRunCondition(runCondition)
 }
-func removeTabletCells(yc components.YtsaurusClient, master components.Component2) Step {
+func removeTabletCells(yc components.YtsaurusClient2, master components.Component2) Step {
 	action := func(ctx context.Context) error {
 		return yc.RemoveTableCells(ctx)
 	}
@@ -170,7 +170,7 @@ func removeTabletCells(yc components.YtsaurusClient, master components.Component
 	runCondition := getFullUpdateCondition(yc, master)
 	return newActionStep("removeTabletCells", action, doneCheck).WithRunCondition(runCondition)
 }
-func buildMasterSnapshots(yc components.YtsaurusClient, master components.Component2) Step {
+func buildMasterSnapshots(yc components.YtsaurusClient2, master components.Component2) Step {
 	action := func(context.Context) error {
 		// use ytclient code
 		// yc.ytClient.RemoveNode
@@ -186,7 +186,7 @@ func buildMasterSnapshots(yc components.YtsaurusClient, master components.Compon
 }
 
 // maybe it shouldn't be inside master at all
-func masterExitReadOnly(yc components.YtsaurusClient, master components.Component2) Step {
+func masterExitReadOnly(yc components.YtsaurusClient2, master components.Component2) Step {
 	action := func(ctx context.Context) error {
 		masterImpl := master.(*components.Master)
 		return masterImpl.DoExitReadOnly(ctx)
@@ -196,7 +196,7 @@ func masterExitReadOnly(yc components.YtsaurusClient, master components.Componen
 	}
 	return newActionStep("masterExitReadOnly", action, doneCheck)
 }
-func recoverTableCells(yc components.YtsaurusClient, master components.Component2) Step {
+func recoverTableCells(yc components.YtsaurusClient2, master components.Component2) Step {
 	action := func(ctx context.Context) error {
 		return yc.RecoverTableCells(ctx)
 	}
@@ -233,7 +233,7 @@ func updateQTState() Step {
 	}
 	return newActionStep("updateQTState", action, doneCheck)
 }
-func disableSafeMode(yc components.YtsaurusClient) Step {
+func disableSafeMode(yc components.YtsaurusClient2) Step {
 	action := func(ctx context.Context) error {
 		return yc.DisableSafeMode(ctx)
 	}

--- a/controllers/ytsaurus_steps.go
+++ b/controllers/ytsaurus_steps.go
@@ -31,11 +31,11 @@ func NewYtsaurus(ctx context.Context, ytsaurusProxy *apiProxy.Ytsaurus) (*Ytsaur
 
 	discoveryStep := newComponentStep(comps.discovery)
 	masterStep := newComponentStep(comps.master)
-	//var httpProxiesSteps []Step
-	//for _, hp := range comps.httpProxies {
-	//	httpProxiesSteps = append(httpProxiesSteps, newComponentStep(hp))
-	//}
-	//ytsaurusClientStep := newComponentStep(comps.ytClient)
+	var httpProxiesSteps []Step
+	for _, hp := range comps.httpProxies {
+		httpProxiesSteps = append(httpProxiesSteps, newComponentStep(hp))
+	}
+	ytsaurusClientStep := newComponentStep(comps.ytClient)
 	//var dataNodesSteps []Step
 	//for _, dn := range comps.dataNodes {
 	//	dataNodesSteps = append(dataNodesSteps, newComponentStep(dn))
@@ -49,8 +49,8 @@ func NewYtsaurus(ctx context.Context, ytsaurusProxy *apiProxy.Ytsaurus) (*Ytsaur
 		//buildMasterSnapshots(),
 		discoveryStep,
 		masterStep,
-		//httpProxiesSteps,
-		//ytsaurusClientStep,
+		httpProxiesSteps,
+		ytsaurusClientStep,
 		//dataNodesSteps,
 		// (optional) ui (depends on master)
 		// (optional) rpcproxies (depends on master)

--- a/controllers/ytsaurus_steps_test.go
+++ b/controllers/ytsaurus_steps_test.go
@@ -58,6 +58,7 @@ func (yc *fakeYtClient) StartBuildingMasterSnapshots(context.Context) error    {
 func (yc *fakeYtClient) AreMasterSnapshotsBuilt(context.Context) (bool, error) {
 	return false, nil
 }
+func (yc *fakeYtClient) ClearUpdateStatus(context.Context) error { return nil }
 
 func TestStepChosenCorrectly(t *testing.T) {
 	httpProxies := []components.Component2{

--- a/controllers/ytsaurus_steps_test.go
+++ b/controllers/ytsaurus_steps_test.go
@@ -80,7 +80,7 @@ func TestStepChosenCorrectly(t *testing.T) {
 		Conditions:   nil,
 		UpdateStatus: ytv1.UpdateStatus{State: ytv1.UpdateStateNone},
 	}
-	steps, err := NewYtsaurusSteps(store, ytsaurusStatus, nil)
+	steps, err := NewYtsaurusSteps(store, &ytsaurusStatus, nil)
 	require.NoError(t, err)
 
 	step, status, err := steps.getNextStep(context.Background())

--- a/controllers/ytsaurus_steps_test.go
+++ b/controllers/ytsaurus_steps_test.go
@@ -1,0 +1,90 @@
+package controllers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.ytsaurus.tech/yt/go/yt"
+
+	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
+	"github.com/ytsaurus/yt-k8s-operator/pkg/components"
+)
+
+type fakeComponent struct {
+	name   string
+	status components.ComponentStatus
+}
+
+func (c fakeComponent) Fetch(context.Context) error { return nil }
+func (c fakeComponent) Sync(context.Context) error  { return nil }
+func (c fakeComponent) Sync2(context.Context) error { return nil }
+func (c fakeComponent) Status(context.Context) components.ComponentStatus {
+	return c.status
+}
+func (c fakeComponent) Status2(context.Context) (components.ComponentStatus, error) {
+	return c.status, nil
+}
+func (c fakeComponent) GetName() string {
+	return c.name
+}
+func (c fakeComponent) GetLabel() string {
+	return c.name + "-label"
+}
+func (c fakeComponent) SetReadyCondition(components.ComponentStatus) {}
+func (c fakeComponent) IsUpdatable() bool                            { return false }
+
+type fakeYtClient struct {
+	fakeComponent
+}
+
+func (yc *fakeYtClient) GetYtClient() yt.Client { return nil }
+func (yc *fakeYtClient) HandlePossibilityCheck(context.Context) (bool, string, error) {
+	return false, "", nil
+}
+func (yc *fakeYtClient) EnableSafeMode(context.Context) error                   { return nil }
+func (yc *fakeYtClient) DisableSafeMode(context.Context) error                  { return nil }
+func (yc *fakeYtClient) IsSafeModeEnabled(context.Context) (bool, error)        { return false, nil }
+func (yc *fakeYtClient) SaveTableCellsAndUpdateState(ctx context.Context) error { return nil }
+func (yc *fakeYtClient) IsTableCellsSaved() bool                                { return false }
+func (yc *fakeYtClient) RemoveTableCells(context.Context) error                 { return nil }
+func (yc *fakeYtClient) RecoverTableCells(context.Context) error                { return nil }
+func (yc *fakeYtClient) AreTabletCellsRemoved(context.Context) (bool, error)    { return false, nil }
+func (yc *fakeYtClient) AreTabletCellsRecovered(context.Context) (bool, error)  { return false, nil }
+func (yc *fakeYtClient) StartBuildMasterSnapshots(ctx context.Context) error    { return nil }
+func (yc *fakeYtClient) IsMasterReadOnly(context.Context) (bool, error)         { return false, nil }
+
+func TestStepChosenCorrectly(t *testing.T) {
+	httpProxies := []components.Component2{
+		fakeComponent{"HTTPProxy", components.SimpleStatus(components.SyncStatusReady)},
+	}
+	dataNodes := []components.Component2{
+		fakeComponent{"DataNodes", components.SimpleStatus(components.SyncStatusReady)},
+	}
+	ytClient := fakeYtClient{
+		fakeComponent{
+			name:   "ytclient",
+			status: components.SimpleStatus(components.SyncStatusReady),
+		},
+	}
+	store := componentsStore{
+		discovery:   fakeComponent{"Discovery", components.SimpleStatus(components.SyncStatusReady)},
+		master:      fakeComponent{"Master", components.SimpleStatus(components.SyncStatusNeedLocalUpdate)},
+		httpProxies: httpProxies,
+		ytClient:    &ytClient,
+		dataNodes:   dataNodes,
+	}
+
+	ytsaurusStatus := ytv1.YtsaurusStatus{
+		State:        ytv1.ClusterStateRunning,
+		Conditions:   nil,
+		UpdateStatus: ytv1.UpdateStatus{State: ytv1.UpdateStateNone},
+	}
+	steps, err := NewYtsaurusSteps(store, ytsaurusStatus)
+	require.NoError(t, err)
+
+	step, status, err := steps.getNextStep(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, "Master", string(step.GetName()))
+}

--- a/controllers/ytsaurus_steps_test.go
+++ b/controllers/ytsaurus_steps_test.go
@@ -53,6 +53,11 @@ func (yc *fakeYtClient) AreTabletCellsRemoved(context.Context) (bool, error)   {
 func (yc *fakeYtClient) AreTabletCellsRecovered(context.Context) (bool, error) { return false, nil }
 func (yc *fakeYtClient) StartBuildMasterSnapshots(ctx context.Context) error   { return nil }
 func (yc *fakeYtClient) IsMasterReadOnly(context.Context) (bool, error)        { return false, nil }
+func (yc *fakeYtClient) SaveMasterMonitoringPaths(context.Context) error       { return nil }
+func (yc *fakeYtClient) StartBuildingMasterSnapshots(context.Context) error    { return nil }
+func (yc *fakeYtClient) AreMasterSnapshotsBuilt(context.Context) (bool, error) {
+	return false, nil
+}
 
 func TestStepChosenCorrectly(t *testing.T) {
 	httpProxies := []components.Component2{

--- a/controllers/ytsaurus_steps_test.go
+++ b/controllers/ytsaurus_steps_test.go
@@ -42,17 +42,17 @@ func (yc *fakeYtClient) GetYtClient() yt.Client { return nil }
 func (yc *fakeYtClient) HandlePossibilityCheck(context.Context) (bool, string, error) {
 	return false, "", nil
 }
-func (yc *fakeYtClient) EnableSafeMode(context.Context) error                   { return nil }
-func (yc *fakeYtClient) DisableSafeMode(context.Context) error                  { return nil }
-func (yc *fakeYtClient) IsSafeModeEnabled(context.Context) (bool, error)        { return false, nil }
-func (yc *fakeYtClient) SaveTableCellsAndUpdateState(ctx context.Context) error { return nil }
-func (yc *fakeYtClient) IsTableCellsSaved() bool                                { return false }
-func (yc *fakeYtClient) RemoveTableCells(context.Context) error                 { return nil }
-func (yc *fakeYtClient) RecoverTableCells(context.Context) error                { return nil }
-func (yc *fakeYtClient) AreTabletCellsRemoved(context.Context) (bool, error)    { return false, nil }
-func (yc *fakeYtClient) AreTabletCellsRecovered(context.Context) (bool, error)  { return false, nil }
-func (yc *fakeYtClient) StartBuildMasterSnapshots(ctx context.Context) error    { return nil }
-func (yc *fakeYtClient) IsMasterReadOnly(context.Context) (bool, error)         { return false, nil }
+func (yc *fakeYtClient) EnableSafeMode(context.Context) error                  { return nil }
+func (yc *fakeYtClient) DisableSafeMode(context.Context) error                 { return nil }
+func (yc *fakeYtClient) IsSafeModeEnabled() bool                               { return false }
+func (yc *fakeYtClient) SaveTableCells(ctx context.Context) error              { return nil }
+func (yc *fakeYtClient) AreTableCellsSaved() bool                              { return false }
+func (yc *fakeYtClient) RemoveTableCells(context.Context) error                { return nil }
+func (yc *fakeYtClient) RecoverTableCells(context.Context) error               { return nil }
+func (yc *fakeYtClient) AreTabletCellsRemoved(context.Context) (bool, error)   { return false, nil }
+func (yc *fakeYtClient) AreTabletCellsRecovered(context.Context) (bool, error) { return false, nil }
+func (yc *fakeYtClient) StartBuildMasterSnapshots(ctx context.Context) error   { return nil }
+func (yc *fakeYtClient) IsMasterReadOnly(context.Context) (bool, error)        { return false, nil }
 
 func TestStepChosenCorrectly(t *testing.T) {
 	httpProxies := []components.Component2{
@@ -80,7 +80,7 @@ func TestStepChosenCorrectly(t *testing.T) {
 		Conditions:   nil,
 		UpdateStatus: ytv1.UpdateStatus{State: ytv1.UpdateStateNone},
 	}
-	steps, err := NewYtsaurusSteps(store, ytsaurusStatus)
+	steps, err := NewYtsaurusSteps(store, ytsaurusStatus, nil)
 	require.NoError(t, err)
 
 	step, status, err := steps.getNextStep(context.Background())

--- a/controllers/ytsaurus_sync.go
+++ b/controllers/ytsaurus_sync.go
@@ -42,7 +42,12 @@ func (r *YtsaurusReconciler) SyncNew(ctx context.Context, resource *ytv1.Ytsauru
 	}
 
 	ytsaurusProxy := apiProxy.NewYtsaurus(resource, r.Client, r.Recorder, r.Scheme)
-	ytsaurusSteps, err := NewYtsaurusSteps(ctx, ytsaurusProxy)
+	cm, err := NewComponentManager(ytsaurusProxy)
+	if err != nil {
+		return requeueASAP, err
+	}
+
+	ytsaurusSteps, err := NewYtsaurusSteps(cm.allComponents, resource.Status)
 	if err != nil {
 		logger.Error(err, "failed to create ytsaurus steps")
 		return requeueASAP, err

--- a/controllers/ytsaurus_sync.go
+++ b/controllers/ytsaurus_sync.go
@@ -1,0 +1,52 @@
+package controllers
+
+import (
+	"context"
+	"time"
+
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
+	apiProxy "github.com/ytsaurus/yt-k8s-operator/pkg/apiproxy"
+)
+
+var (
+	requeueNot = ctrl.Result{Requeue: false}
+	// I'm actually not sure that this means now
+	// TODO: validate
+	requeueASAP     = ctrl.Result{Requeue: true}
+	requeueSoon     = ctrl.Result{RequeueAfter: 1 * time.Second}
+	requeueBitLater = ctrl.Result{RequeueAfter: 10 * time.Second}
+	requeueLater    = ctrl.Result{RequeueAfter: 1 * time.Minute}
+)
+
+func (r *YtsaurusReconciler) SyncNew(ctx context.Context, resource *ytv1.Ytsaurus) (ctrl.Result, error) {
+	var err error
+	logger := log.FromContext(ctx)
+
+	if !resource.Spec.IsManaged {
+		logger.Info("Ytsaurus cluster is not managed by controller, do nothing")
+		return requeueLater, nil
+	}
+
+	ytsaurus := apiProxy.NewYtsaurus(resource, r.Client, r.Recorder, r.Scheme)
+	ytsaurusComponent, err := NewYtsaurus(ctx, ytsaurus)
+	if err != nil {
+		return requeueASAP, err
+	}
+
+	status, err := ytsaurusComponent.Status(ctx)
+	if err != nil {
+		return requeueASAP, err
+	}
+	if !status.IsReady() {
+		// TODO: maybe we need a different behaviour for different statuses
+		// TODO: maybe we need a different requeue time for different statuses
+		err = ytsaurusComponent.Sync(ctx)
+		return requeueSoon, err
+	}
+
+	logger.Info("Ytsaurus is running and happy")
+	return requeueNot, nil
+}

--- a/controllers/ytsaurus_sync.go
+++ b/controllers/ytsaurus_sync.go
@@ -39,11 +39,11 @@ func (r *YtsaurusReconciler) SyncNew(ctx context.Context, resource *ytv1.Ytsauru
 	}
 
 	ytsaurusProxy := apiProxy.NewYtsaurus(resource, r.Client, r.Recorder, r.Scheme)
-	ytsaurusComponent, err := NewYtsaurus(ytsaurusProxy)
+	ytsaurusSteps, err := NewYtsaurusSteps(ytsaurusProxy)
 	if err != nil {
 		return requeueASAP, err
 	}
-	state, err := ytsaurusComponent.Sync(ctx)
+	state, err := ytsaurusSteps.Sync(ctx)
 	if err != nil {
 		return requeueASAP, err
 	}

--- a/controllers/ytsaurus_sync.go
+++ b/controllers/ytsaurus_sync.go
@@ -48,6 +48,9 @@ func (r *YtsaurusReconciler) SyncNew(ctx context.Context, resource *ytv1.Ytsauru
 		// TODO: maybe we need a different behaviour for different statuses
 		// TODO: maybe we need a different requeue time for different statuses
 		err = ytsaurusComponent.Sync(ctx)
+		if err != nil {
+			logger.Error(err, "failed to sync ytsaurus")
+		}
 		return requeueSoon, err
 	}
 

--- a/controllers/ytsaurus_sync.go
+++ b/controllers/ytsaurus_sync.go
@@ -47,7 +47,7 @@ func (r *YtsaurusReconciler) SyncNew(ctx context.Context, resource *ytv1.Ytsauru
 		return requeueASAP, err
 	}
 
-	ytsaurusSteps, err := NewYtsaurusSteps(cm.allComponents, resource.Status, ytsaurusProxy)
+	ytsaurusSteps, err := NewYtsaurusSteps(cm.allComponents, &resource.Status, ytsaurusProxy)
 	if err != nil {
 		logger.Error(err, "failed to create ytsaurus steps")
 		return requeueASAP, err

--- a/controllers/ytsaurus_sync.go
+++ b/controllers/ytsaurus_sync.go
@@ -47,7 +47,7 @@ func (r *YtsaurusReconciler) SyncNew(ctx context.Context, resource *ytv1.Ytsauru
 		return requeueASAP, err
 	}
 
-	ytsaurusSteps, err := NewYtsaurusSteps(cm.allComponents, resource.Status)
+	ytsaurusSteps, err := NewYtsaurusSteps(cm.allComponents, resource.Status, ytsaurusProxy)
 	if err != nil {
 		logger.Error(err, "failed to create ytsaurus steps")
 		return requeueASAP, err

--- a/pkg/apiproxy/ytsaurus.go
+++ b/pkg/apiproxy/ytsaurus.go
@@ -108,6 +108,15 @@ func (c *Ytsaurus) SaveUpdateState(ctx context.Context, updateState ytv1.UpdateS
 	return nil
 }
 
+func (c *Ytsaurus) SaveUpdateStatus(ctx context.Context) error {
+	logger := log.FromContext(ctx)
+	if err := c.apiProxy.UpdateStatus(ctx); err != nil {
+		logger.Error(err, "unable to update Ytsaurus update state")
+		return err
+	}
+	return nil
+}
+
 func (c *Ytsaurus) SetStatusCondition(condition metav1.Condition) {
 	meta.SetStatusCondition(&c.ytsaurus.Status.Conditions, condition)
 }

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -13,19 +13,6 @@ import (
 
 type SyncStatus string
 
-// I suggest to change semantics of statuses:
-// "Blocked" — nothing can be done by operator, human needed
-// i.e. need to do full update but EnableFullUpdate = false or config generator failing with error
-// "NeedFullUpdate" >> *this component* sync will require it's full rebuild (recreate pods and so on)
-// (currently it means ytsaurus needs full update).
-// maybe rename like "NeedSyncWithRebuild".
-// "NeedLocalUpdate" >> "NeedSync" there are some changes, but it is not expected that component will be
-// recreated (or maybe nothing bad can happen of such recreating)
-// "Ready" — all good
-// "Updating" — not ready, but nothing to do for operator
-// "Pending" — currently this means not ready and waiting for some other component to be ready,
-// I'm not sure if we need this distinction in practice.
-
 /*
 I suggest in future we have statuses:
  1. Ready = all good

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -13,6 +13,19 @@ import (
 
 type SyncStatus string
 
+// I suggest to change semantics of statuses:
+// "Blocked" — nothing can be done by operator, human needed
+// i.e. need to do full update but EnableFullUpdate = false or config generator failing with error
+// "NeedFullUpdate" >> *this component* sync will require it's full rebuild (recreate pods and so on)
+// (currently it means ytsaurus needs full update).
+// maybe rename like "NeedSyncWithRebuild".
+// "NeedLocalUpdate" >> "NeedSync" there are some changes, but it is not expected that component will be
+// recreated (or maybe nothing bad can happen of such recreating)
+// "Ready" — all good
+// "Updating" — not ready, but nothing to do for operator
+// "Pending" — currently this means not ready and waiting for some other component to be ready,
+// I'm not sure if we need this distinction in practice.
+
 const (
 	SyncStatusBlocked         SyncStatus = "Blocked"
 	SyncStatusNeedFullUpdate  SyncStatus = "NeedFullUpdate"

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -3,10 +3,12 @@ package components
 import (
 	"context"
 	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/ytsaurus/yt-k8s-operator/pkg/apiproxy"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/labeller"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type SyncStatus string

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -26,6 +26,14 @@ type SyncStatus string
 // "Pending" — currently this means not ready and waiting for some other component to be ready,
 // I'm not sure if we need this distinction in practice.
 
+/*
+I suggest in future we have statuses:
+ 1. Ready = all good
+ 2. NeedUpdate = sync me
+ 3. NeedFullUpdate = sync me (but I will recreate pods, just saying)
+ 4. Updating = nothing to do, come later
+ 5. Blocked = human please fix you configs or bugs in code
+*/
 const (
 	SyncStatusBlocked         SyncStatus = "Blocked"
 	SyncStatusNeedFullUpdate  SyncStatus = "NeedFullUpdate"

--- a/pkg/components/component_extra.go
+++ b/pkg/components/component_extra.go
@@ -2,12 +2,16 @@ package components
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"time"
 
+	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yt"
 	"go.ytsaurus.tech/yt/go/yt/ythttp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/resources"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
@@ -125,34 +129,31 @@ func (hp *HTTPProxy) Sync2(ctx context.Context) error {
 	return nil
 }
 
+func (n *DataNode) Status2(ctx context.Context) (ComponentStatus, error) {
+	if n.server.needUpdate() {
+		return SimpleStatus(SyncStatusNeedFullUpdate), nil
+	}
+	// TODO: we don't checking master running status anymore
+	if n.server.needSync2() {
+		return SimpleStatus(SyncStatusNeedLocalUpdate), nil
+	}
+	if !n.server.arePodsReady(ctx) {
+		return WaitingStatus(SyncStatusUpdating, "pods"), nil
+	}
+	return SimpleStatus(SyncStatusReady), nil
+}
+func (n *DataNode) Sync2(ctx context.Context) error {
+	return n.server.Sync(ctx)
+}
+
 func (yc *ytsaurusClient) Status2(_ context.Context) (ComponentStatus, error) {
 	// FIXME: stopped checking hp running status:
 	// though but maybe we still should?
 	// It depends on if hps could be deployed before master or not
 	// maybe we need some action-step for healthcheck before ytsaurus client
 
-	if yc.secret.NeedSync(consts.TokenSecretKey, "") {
-		return WaitingStatus(SyncStatusNeedLocalUpdate, yc.secret.Name()), nil
-	}
-
-	// TODO: understand how check for initUserJob runs
-	// we need to differentiate when it needed to be run and when it already ran
-
-	return SimpleStatus(SyncStatusReady), nil
-}
-func (yc *ytsaurusClient) Sync2(ctx context.Context) error {
+	// FIXME: Why this not in New?
 	var err error
-
-	if yc.secret.NeedSync(consts.TokenSecretKey, "") {
-		s := yc.secret.Build()
-		s.StringData = map[string]string{
-			consts.TokenSecretKey: ytconfig.RandString(30),
-		}
-		err = yc.secret.Sync(ctx)
-	}
-
-	// todo run init job if necessary
-
 	if yc.ytClient == nil {
 		token, _ := yc.secret.GetValue(consts.TokenSecretKey)
 		timeout := time.Second * 10
@@ -170,25 +171,299 @@ func (yc *ytsaurusClient) Sync2(ctx context.Context) error {
 		})
 
 		if err != nil {
+			return ComponentStatus{}, err
+		}
+	}
+
+	if yc.secret.NeedSync(consts.TokenSecretKey, "") {
+		return WaitingStatus(SyncStatusNeedLocalUpdate, yc.secret.Name()), nil
+	}
+
+	// TODO: understand how check for initUserJob runs
+	// we need to differentiate when it needed to be run and when it already ran
+
+	return SimpleStatus(SyncStatusReady), nil
+}
+func (yc *ytsaurusClient) Sync2(ctx context.Context) error {
+	var err error
+	if yc.secret.NeedSync(consts.TokenSecretKey, "") {
+		s := yc.secret.Build()
+		s.StringData = map[string]string{
+			consts.TokenSecretKey: ytconfig.RandString(30),
+		}
+		err = yc.secret.Sync(ctx)
+		if err != nil {
 			return err
 		}
 	}
+
+	// todo run init job if necessary
+
 	return nil
 }
+func (yc *ytsaurusClient) HandlePossibilityCheck(ctx context.Context) (ok bool, msg string, err error) {
+	if !yc.ytsaurus.GetResource().Spec.EnableFullUpdate {
+		msg = "Full update is not enabled"
+		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+			Type:    consts.ConditionNoPossibility,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Update",
+			Message: msg,
+		})
+		return false, msg, nil
+	}
 
-func (n *DataNode) Status2(ctx context.Context) (ComponentStatus, error) {
-	if n.server.needUpdate() {
-		return SimpleStatus(SyncStatusNeedFullUpdate), nil
+	// Check tablet cell bundles.
+	notGoodBundles, err := GetNotGoodTabletCellBundles(ctx, yc.ytClient)
+
+	if err != nil {
+		return
 	}
-	// TODO: we don't checking master running status anymore
-	if n.server.needSync2() {
-		return SimpleStatus(SyncStatusNeedLocalUpdate), nil
+
+	if len(notGoodBundles) > 0 {
+		msg = fmt.Sprintf("Tablet cell bundles (%v) aren't in 'good' health", notGoodBundles)
+		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+			Type:    consts.ConditionNoPossibility,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Update",
+			Message: msg,
+		})
+		return false, msg, nil
 	}
-	if !n.server.arePodsReady(ctx) {
-		return WaitingStatus(SyncStatusUpdating, "pods"), nil
+
+	// Check LVC.
+	lvcCount := 0
+	err = yc.ytClient.GetNode(ctx, ypath.Path("//sys/lost_vital_chunks/@count"), &lvcCount, nil)
+	if err != nil {
+		return
 	}
-	return SimpleStatus(SyncStatusReady), nil
+
+	if lvcCount > 0 {
+		msg = fmt.Sprintf("There are lost vital chunks: %v", lvcCount)
+		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+			Type:    consts.ConditionNoPossibility,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Update",
+			Message: msg,
+		})
+		return false, msg, nil
+	}
+
+	// Check QMC.
+	qmcCount := 0
+	err = yc.ytClient.GetNode(ctx, ypath.Path("//sys/quorum_missing_chunks/@count"), &qmcCount, nil)
+	if err != nil {
+		return
+	}
+
+	if qmcCount > 0 {
+		msg = fmt.Sprintf("There are quorum missing chunks: %v", qmcCount)
+		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+			Type:    consts.ConditionNoPossibility,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Update",
+			Message: msg,
+		})
+		return false, msg, nil
+	}
+
+	// Check masters.
+	primaryMasterAddresses := make([]string, 0)
+	err = yc.ytClient.ListNode(ctx, ypath.Path("//sys/primary_masters"), &primaryMasterAddresses, nil)
+	if err != nil {
+		return
+	}
+
+	leadingPrimaryMasterCount := 0
+	followingPrimaryMasterCount := 0
+
+	for _, primaryMasterAddress := range primaryMasterAddresses {
+		var hydra MasterHydra
+		err = yc.ytClient.GetNode(
+			ctx,
+			ypath.Path(fmt.Sprintf("//sys/primary_masters/%v/orchid/monitoring/hydra", primaryMasterAddress)),
+			&hydra,
+			nil)
+		if err != nil {
+			return
+		}
+
+		if !hydra.Active {
+			msg = fmt.Sprintf("There is a non-active master: %v", primaryMasterAddresses)
+			yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+				Type:    consts.ConditionNoPossibility,
+				Status:  metav1.ConditionTrue,
+				Reason:  "Update",
+				Message: msg,
+			})
+			return false, msg, nil
+		}
+
+		switch hydra.State {
+		case MasterStateLeading:
+			leadingPrimaryMasterCount += 1
+		case MasterStateFollowing:
+			followingPrimaryMasterCount += 1
+		}
+	}
+
+	if !(leadingPrimaryMasterCount == 1 && followingPrimaryMasterCount+1 == len(primaryMasterAddresses)) {
+		msg = fmt.Sprintf("There is no leader or some peer is not active")
+		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+			Type:    consts.ConditionNoPossibility,
+			Status:  metav1.ConditionTrue,
+			Reason:  "Update",
+			Message: msg,
+		})
+		return false, msg, nil
+	}
+
+	msg = "Update is possible"
+	yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+		Type:    consts.ConditionHasPossibility,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: msg,
+	})
+	return true, "", nil
 }
-func (n *DataNode) Sync2(ctx context.Context) error {
-	return n.server.Sync(ctx)
+func (yc *ytsaurusClient) EnableSafeMode(ctx context.Context) error {
+	return yc.ytClient.SetNode(ctx, ypath.Path("//sys/@enable_safe_mode"), true, nil)
+}
+func (yc *ytsaurusClient) DisableSafeMode(ctx context.Context) error {
+	return yc.ytClient.SetNode(ctx, ypath.Path("//sys/@enable_safe_mode"), false, nil)
+}
+func (yc *ytsaurusClient) IsSafeModeEnabled(ctx context.Context) (bool, error) {
+	enableSafeModePath := "//sys/@enable_safe_mode"
+	exists, err := yc.ytClient.NodeExists(ctx, ypath.Path(enableSafeModePath), nil)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+
+	var isEnabled bool
+	err = yc.ytClient.GetNode(ctx, ypath.Path(enableSafeModePath), &isEnabled, nil)
+	return isEnabled, err
+}
+func (yc *ytsaurusClient) saveTableCells(ctx context.Context) error {
+	var tabletCellBundles []ytv1.TabletCellBundleInfo
+	err := yc.ytClient.ListNode(
+		ctx,
+		ypath.Path("//sys/tablet_cell_bundles"),
+		&tabletCellBundles,
+		&yt.ListNodeOptions{Attributes: []string{"tablet_cell_count"}})
+
+	if err != nil {
+		return err
+	}
+
+	yc.ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles = tabletCellBundles
+
+	yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+		Type:    consts.ConditionTabletCellsSaved,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Tablet cells were saved",
+	})
+	return nil
+}
+func (yc *ytsaurusClient) SaveTableCellsAndUpdateState(ctx context.Context) error {
+	err := yc.saveTableCells(ctx)
+	if err != nil {
+		return err
+	}
+	return yc.ytsaurus.SaveUpdateStatus(ctx)
+}
+func (yc *ytsaurusClient) IsTableCellsSaved() bool {
+	// FIXME: is it a good check? What if we have 0 table cells for example?
+	return len(yc.ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles) != 0
+}
+func (yc *ytsaurusClient) RemoveTableCells(ctx context.Context) error {
+	// FIXME: this needs locking or it can't be two reconciler loops in the same time?
+	var tabletCells []string
+	err := yc.ytClient.ListNode(
+		ctx,
+		ypath.Path("//sys/tablet_cells"),
+		&tabletCells,
+		nil)
+
+	if err != nil {
+		return err
+	}
+
+	for _, tabletCell := range tabletCells {
+		err = yc.ytClient.RemoveNode(
+			ctx,
+			ypath.Path(fmt.Sprintf("//sys/tablet_cells/%s", tabletCell)),
+			nil)
+		if err != nil {
+			return err
+		}
+	}
+
+	yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+		Type:    consts.ConditionTabletCellsRemovingStarted,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Tablet cells removing was started",
+	})
+	return nil
+}
+func (yc *ytsaurusClient) AreTabletCellsRemoved(ctx context.Context) (bool, error) {
+	var tabletCells []string
+	err := yc.ytClient.ListNode(
+		ctx,
+		ypath.Path("//sys/tablet_cells"),
+		&tabletCells,
+		nil)
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(tabletCells) != 0 {
+		return false, err
+	}
+	return true, nil
+}
+func (yc *ytsaurusClient) AreTabletCellsRecovered(ctx context.Context) (bool, error) {
+	// TODO: what if we have no table cells
+	if len(yc.ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles) != 0 {
+		return false, nil
+	}
+
+	var tabletCells []string
+	err := yc.ytClient.ListNode(
+		ctx,
+		ypath.Path("//sys/tablet_cells"),
+		&tabletCells,
+		nil)
+
+	if err != nil {
+		return false, err
+	}
+
+	if len(tabletCells) == 0 {
+		return false, err
+	}
+	return true, nil
+}
+func (yc *ytsaurusClient) RecoverTableCells(ctx context.Context) error {
+	var err error
+	for _, bundle := range yc.ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles {
+		err = CreateTabletCells(ctx, yc.ytClient, bundle.Name, bundle.TabletCellCount)
+		if err != nil {
+			return err
+		}
+	}
+	yc.ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles = make([]ytv1.TabletCellBundleInfo, 0)
+	return yc.ytsaurus.SaveUpdateStatus(ctx)
+}
+func (yc *ytsaurusClient) IsMasterReadOnly(ctx context.Context) (bool, error) {
+	var isReadOnly bool
+	// FIXME: can read only be checked that way?
+	err := yc.ytClient.GetNode(ctx, ypath.Path("//sys/@hydra_read_only"), &isReadOnly, nil)
+	return isReadOnly, err
 }

--- a/pkg/components/component_extra.go
+++ b/pkg/components/component_extra.go
@@ -176,7 +176,19 @@ func (yc *ytsaurusClient) Sync2(ctx context.Context) error {
 	return nil
 }
 
-func (n *DataNode) Status2(_ context.Context) (ComponentStatus, error) {
+func (n *DataNode) Status2(ctx context.Context) (ComponentStatus, error) {
+	if n.server.needUpdate() {
+		return SimpleStatus(SyncStatusNeedFullUpdate), nil
+	}
+	// TODO: we don't checking master running status anymore
+	if n.server.needSync2() {
+		return SimpleStatus(SyncStatusPending), nil
+	}
+	if !n.server.arePodsReady(ctx) {
+		return WaitingStatus(SyncStatusPending, "pods"), nil
+	}
 	return SimpleStatus(SyncStatusReady), nil
 }
-func (n *DataNode) Sync2(context.Context) error { return nil }
+func (n *DataNode) Sync2(ctx context.Context) error {
+	return n.server.Sync(ctx)
+}

--- a/pkg/components/component_extra.go
+++ b/pkg/components/component_extra.go
@@ -40,6 +40,22 @@ type Component2 interface {
 	Sync2(context.Context) error
 }
 
+type YtsaurusClient2 interface {
+	YtsaurusClient
+	Component2
+	HandlePossibilityCheck(context.Context) (bool, string, error)
+	EnableSafeMode(context.Context) error
+	DisableSafeMode(context.Context) error
+	IsSafeModeEnabled(context.Context) (bool, error)
+	SaveTableCellsAndUpdateState(ctx context.Context) error
+	IsTableCellsSaved() bool
+	RemoveTableCells(context.Context) error
+	RecoverTableCells(context.Context) error
+	AreTabletCellsRemoved(context.Context) (bool, error)
+	AreTabletCellsRecovered(context.Context) (bool, error)
+	IsMasterReadOnly(context.Context) (bool, error)
+}
+
 func (d *Discovery) Status2(ctx context.Context) (ComponentStatus, error) {
 	// exists but images or config is not up-to-date
 	if d.server.needUpdate() {

--- a/pkg/components/component_extra.go
+++ b/pkg/components/component_extra.go
@@ -56,6 +56,8 @@ type YtsaurusClient2 interface {
 	SaveMasterMonitoringPaths(context.Context) error
 	StartBuildingMasterSnapshots(context.Context) error
 	AreMasterSnapshotsBuilt(context.Context) (bool, error)
+
+	ClearUpdateStatus(context.Context) error
 }
 
 func (d *Discovery) Status2(ctx context.Context) (ComponentStatus, error) {
@@ -503,4 +505,7 @@ func (yc *ytsaurusClient) AreMasterSnapshotsBuilt(ctx context.Context) (bool, er
 		}
 	}
 	return true, nil
+}
+func (yc *ytsaurusClient) ClearUpdateStatus(ctx context.Context) error {
+	return yc.ytsaurus.ClearUpdateStatus(ctx)
 }

--- a/pkg/components/component_extra.go
+++ b/pkg/components/component_extra.go
@@ -53,6 +53,7 @@ type YtsaurusClient2 interface {
 	RecoverTableCells(context.Context) error
 	AreTabletCellsRemoved(context.Context) (bool, error)
 	AreTabletCellsRecovered(context.Context) (bool, error)
+	StartBuildMasterSnapshots(ctx context.Context) error
 	IsMasterReadOnly(context.Context) (bool, error)
 }
 

--- a/pkg/components/component_extra.go
+++ b/pkg/components/component_extra.go
@@ -1,0 +1,40 @@
+package components
+
+import (
+	"context"
+)
+
+func (s ComponentStatus) IsReady() bool {
+	return s.SyncStatus == SyncStatusReady
+}
+
+type Component2 interface {
+	Component
+	Status2(context.Context) (ComponentStatus, error)
+	Sync2(context.Context) error
+}
+
+func (d *Discovery) Status2(_ context.Context) (ComponentStatus, error) {
+	return SimpleStatus(SyncStatusReady), nil
+}
+func (d *Discovery) Sync2(context.Context) error { return nil }
+
+func (m *Master) Status2(_ context.Context) (ComponentStatus, error) {
+	return SimpleStatus(SyncStatusReady), nil
+}
+func (m *Master) Sync2(context.Context) error { return nil }
+
+func (hp *HTTPProxy) Status2(_ context.Context) (ComponentStatus, error) {
+	return SimpleStatus(SyncStatusReady), nil
+}
+func (hp *HTTPProxy) Sync2(context.Context) error { return nil }
+
+func (yc *ytsaurusClient) Status2(_ context.Context) (ComponentStatus, error) {
+	return SimpleStatus(SyncStatusReady), nil
+}
+func (yc *ytsaurusClient) Sync2(context.Context) error { return nil }
+
+func (n *DataNode) Status2(_ context.Context) (ComponentStatus, error) {
+	return SimpleStatus(SyncStatusReady), nil
+}
+func (n *DataNode) Sync2(context.Context) error { return nil }

--- a/pkg/components/component_extra.go
+++ b/pkg/components/component_extra.go
@@ -57,6 +57,15 @@ type YtsaurusClient2 interface {
 	IsMasterReadOnly(context.Context) (bool, error)
 }
 
+var (
+	EnableSafeModeCondition = metav1.Condition{
+		Type:    consts.ConditionSafeModeEnabled,
+		Status:  metav1.ConditionTrue,
+		Reason:  "Update",
+		Message: "Safe mode was enabled",
+	}
+)
+
 func (d *Discovery) Status2(ctx context.Context) (ComponentStatus, error) {
 	// exists but images or config is not up-to-date
 	if d.server.needUpdate() {
@@ -360,17 +369,17 @@ func (yc *ytsaurusClient) HandlePossibilityCheck(ctx context.Context) (ok bool, 
 	return true, "", nil
 }
 func (yc *ytsaurusClient) EnableSafeMode(ctx context.Context) error {
-	err := yc.ytClient.SetNode(ctx, ypath.Path("//sys/@enable_safe_mode"), true, nil)
-	if err != nil {
-		return err
-	}
-	yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-		Type:    consts.ConditionSafeModeEnabled,
-		Status:  metav1.ConditionTrue,
-		Reason:  "Update",
-		Message: "Safe mode was enabled",
-	})
-	return nil
+	return yc.ytClient.SetNode(ctx, ypath.Path("//sys/@enable_safe_mode"), true, nil)
+	//if err != nil {
+	//	return err
+	//}
+	//yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
+	//	Type:    consts.ConditionSafeModeEnabled,
+	//	Status:  metav1.ConditionTrue,
+	//	Reason:  "Update",
+	//	Message: "Safe mode was enabled",
+	//})
+	//return nil
 }
 func (yc *ytsaurusClient) DisableSafeMode(ctx context.Context) error {
 	return yc.ytClient.SetNode(ctx, ypath.Path("//sys/@enable_safe_mode"), false, nil)

--- a/pkg/components/component_extra.go
+++ b/pkg/components/component_extra.go
@@ -8,21 +8,62 @@ func (s ComponentStatus) IsReady() bool {
 	return s.SyncStatus == SyncStatusReady
 }
 
+// needSync2 is a copy of needSync but without ytsaurus status checking
+// (server resources shouldn't know about parent ytsaurus component)
+func (s *serverImpl) needSync2() bool {
+	needReload, err := s.configHelper.NeedReload()
+	if err != nil {
+		needReload = false
+	}
+	return s.configHelper.NeedInit() ||
+		needReload ||
+		!s.exists() ||
+		s.statefulSet.NeedSync(s.instanceSpec.InstanceCount)
+}
+
 type Component2 interface {
 	Component
 	Status2(context.Context) (ComponentStatus, error)
 	Sync2(context.Context) error
 }
 
-func (d *Discovery) Status2(_ context.Context) (ComponentStatus, error) {
-	return SimpleStatus(SyncStatusReady), nil
-}
-func (d *Discovery) Sync2(context.Context) error { return nil }
+func serverStatus2(ctx context.Context, srv server) (ComponentStatus, error) {
+	// exists but images or config is not up-to-date
+	if srv.needUpdate() {
+		return SimpleStatus(SyncStatusPending), nil
+	}
 
-func (m *Master) Status2(_ context.Context) (ComponentStatus, error) {
+	// configMap not exists
+	// OR config is not up-to-date
+	// OR server not exists
+	// OR not enough pods in sts
+	if srv.needSync2() {
+		return SimpleStatus(SyncStatusPending), nil
+	}
+
+	// TODO: possible leaking abstraction, we should only check if server ready or nor
+	if !srv.arePodsReady(ctx) {
+		return SimpleStatus(SyncStatusPending), nil
+	}
+
 	return SimpleStatus(SyncStatusReady), nil
 }
-func (m *Master) Sync2(context.Context) error { return nil }
+
+func (d *Discovery) Status2(ctx context.Context) (ComponentStatus, error) {
+	return serverStatus2(ctx, d.server)
+}
+func (d *Discovery) Sync2(ctx context.Context) error {
+	// TODO: we are dropping this remove pods thing, but should check if it works ok without it.
+	// should we detect `pods are not ready` status and don't do sync
+	// will it make things easier or more observable or faster?
+	return d.server.Sync(ctx)
+}
+
+func (m *Master) Status2(ctx context.Context) (ComponentStatus, error) {
+	return serverStatus2(ctx, m.server)
+
+}
+func (m *Master) Sync2(ctx context.Context) error { return m.doServerSync(ctx) }
 
 func (hp *HTTPProxy) Status2(_ context.Context) (ComponentStatus, error) {
 	return SimpleStatus(SyncStatusReady), nil

--- a/pkg/components/data_node.go
+++ b/pkg/components/data_node.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
 )
 
-type dataNode struct {
+type DataNode struct {
 	componentBase
 	server server
 	master Component
@@ -22,7 +22,7 @@ func NewDataNode(
 	ytsaurus *apiproxy.Ytsaurus,
 	master Component,
 	spec ytv1.DataNodesSpec,
-) Component {
+) *DataNode {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,
@@ -45,7 +45,7 @@ func NewDataNode(
 		},
 	)
 
-	return &dataNode{
+	return &DataNode{
 		componentBase: componentBase{
 			labeller: &l,
 			ytsaurus: ytsaurus,
@@ -56,15 +56,15 @@ func NewDataNode(
 	}
 }
 
-func (n *dataNode) IsUpdatable() bool {
+func (n *DataNode) IsUpdatable() bool {
 	return true
 }
 
-func (n *dataNode) Fetch(ctx context.Context) error {
+func (n *DataNode) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx, n.server)
 }
 
-func (n *dataNode) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (n *DataNode) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(n.ytsaurus.GetClusterState()) && n.server.needUpdate() {
@@ -95,7 +95,7 @@ func (n *dataNode) doSync(ctx context.Context, dry bool) (ComponentStatus, error
 	return SimpleStatus(SyncStatusReady), err
 }
 
-func (n *dataNode) Status(ctx context.Context) ComponentStatus {
+func (n *DataNode) Status(ctx context.Context) ComponentStatus {
 	status, err := n.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -104,7 +104,7 @@ func (n *dataNode) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (n *dataNode) Sync(ctx context.Context) error {
+func (n *DataNode) Sync(ctx context.Context) error {
 	_, err := n.doSync(ctx, false)
 	return err
 }

--- a/pkg/components/discovery.go
+++ b/pkg/components/discovery.go
@@ -11,12 +11,12 @@ import (
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
 )
 
-type discovery struct {
+type Discovery struct {
 	componentBase
 	server server
 }
 
-func NewDiscovery(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) Component {
+func NewDiscovery(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) *Discovery {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,
@@ -37,7 +37,7 @@ func NewDiscovery(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) Compon
 		cfgen.GetDiscoveryConfig,
 	)
 
-	return &discovery{
+	return &Discovery{
 		componentBase: componentBase{
 			labeller: &l,
 			ytsaurus: ytsaurus,
@@ -47,15 +47,15 @@ func NewDiscovery(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus) Compon
 	}
 }
 
-func (d *discovery) IsUpdatable() bool {
+func (d *Discovery) IsUpdatable() bool {
 	return true
 }
 
-func (d *discovery) Fetch(ctx context.Context) error {
+func (d *Discovery) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx, d.server)
 }
 
-func (d *discovery) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (d *Discovery) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(d.ytsaurus.GetClusterState()) && d.server.needUpdate() {
@@ -82,7 +82,7 @@ func (d *discovery) doSync(ctx context.Context, dry bool) (ComponentStatus, erro
 	return SimpleStatus(SyncStatusReady), err
 }
 
-func (d *discovery) Status(ctx context.Context) ComponentStatus {
+func (d *Discovery) Status(ctx context.Context) ComponentStatus {
 	status, err := d.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -91,7 +91,7 @@ func (d *discovery) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (d *discovery) Sync(ctx context.Context) error {
+func (d *Discovery) Sync(ctx context.Context) error {
 	_, err := d.doSync(ctx, false)
 	return err
 }

--- a/pkg/components/httpproxy.go
+++ b/pkg/components/httpproxy.go
@@ -3,17 +3,18 @@ package components
 import (
 	"context"
 
+	"go.ytsaurus.tech/yt/go/yt"
+	corev1 "k8s.io/api/core/v1"
+
 	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/apiproxy"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/labeller"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/resources"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
-	"go.ytsaurus.tech/yt/go/yt"
-	corev1 "k8s.io/api/core/v1"
 )
 
-type httpProxy struct {
+type HTTPProxy struct {
 	componentBase
 	server server
 
@@ -31,7 +32,7 @@ func NewHTTPProxy(
 	cfgen *ytconfig.Generator,
 	ytsaurus *apiproxy.Ytsaurus,
 	masterReconciler Component,
-	spec ytv1.HTTPProxiesSpec) Component {
+	spec ytv1.HTTPProxiesSpec) *HTTPProxy {
 
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
@@ -72,7 +73,7 @@ func NewHTTPProxy(
 	balancingService.SetHttpNodePort(spec.HttpNodePort)
 	balancingService.SetHttpsNodePort(spec.HttpsNodePort)
 
-	return &httpProxy{
+	return &HTTPProxy{
 		componentBase: componentBase{
 			labeller: &l,
 			ytsaurus: ytsaurus,
@@ -87,18 +88,18 @@ func NewHTTPProxy(
 	}
 }
 
-func (hp *httpProxy) IsUpdatable() bool {
+func (hp *HTTPProxy) IsUpdatable() bool {
 	return true
 }
 
-func (hp *httpProxy) Fetch(ctx context.Context) error {
+func (hp *HTTPProxy) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx,
 		hp.server,
 		hp.balancingService,
 	)
 }
 
-func (hp *httpProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
+func (hp *HTTPProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, error) {
 	var err error
 
 	if ytv1.IsReadyToUpdateClusterState(hp.ytsaurus.GetClusterState()) && hp.server.needUpdate() {
@@ -143,7 +144,7 @@ func (hp *httpProxy) doSync(ctx context.Context, dry bool) (ComponentStatus, err
 	return SimpleStatus(SyncStatusReady), err
 }
 
-func (hp *httpProxy) Status(ctx context.Context) ComponentStatus {
+func (hp *HTTPProxy) Status(ctx context.Context) ComponentStatus {
 	status, err := hp.doSync(ctx, true)
 	if err != nil {
 		panic(err)
@@ -152,7 +153,7 @@ func (hp *httpProxy) Status(ctx context.Context) ComponentStatus {
 	return status
 }
 
-func (hp *httpProxy) Sync(ctx context.Context) error {
+func (hp *HTTPProxy) Sync(ctx context.Context) error {
 	_, err := hp.doSync(ctx, false)
 	return err
 }

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -416,6 +416,17 @@ func (m *Master) exitReadOnly(ctx context.Context, dry bool) (*ComponentStatus, 
 	return ptr.T(SimpleStatus(SyncStatusUpdating)), nil
 }
 
+func (m *Master) DoExitReadOnly(ctx context.Context) error {
+	// FIXME: test how it goes if ran several times
+	err := m.exitReadOnlyJob.Fetch(ctx)
+	if err != nil {
+		return err
+	}
+	m.exitReadOnlyJob.SetInitScript(m.createExitReadOnlyScript())
+	_, err = m.exitReadOnlyJob.Sync(ctx, false)
+	return err
+}
+
 func (m *Master) setMasterReadOnlyExitPrepared(ctx context.Context, status metav1.ConditionStatus) {
 	m.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
 		Type:    consts.ConditionMasterExitReadOnlyPrepared,

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -427,6 +427,14 @@ func (m *Master) DoExitReadOnly(ctx context.Context) error {
 	return err
 }
 
+func (m *Master) IsExitReadOnlyDone(ctx context.Context) (bool, error) {
+	err := m.exitReadOnlyJob.Fetch(ctx)
+	if err != nil {
+		return false, err
+	}
+	return m.exitReadOnlyJob.initJob.Completed(), nil
+}
+
 func (m *Master) setMasterReadOnlyExitPrepared(ctx context.Context, status metav1.ConditionStatus) {
 	m.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
 		Type:    consts.ConditionMasterExitReadOnlyPrepared,

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -416,25 +416,6 @@ func (m *Master) exitReadOnly(ctx context.Context, dry bool) (*ComponentStatus, 
 	return ptr.T(SimpleStatus(SyncStatusUpdating)), nil
 }
 
-func (m *Master) DoExitReadOnly(ctx context.Context) error {
-	// FIXME: test how it goes if ran several times
-	err := m.exitReadOnlyJob.Fetch(ctx)
-	if err != nil {
-		return err
-	}
-	m.exitReadOnlyJob.SetInitScript(m.createExitReadOnlyScript())
-	_, err = m.exitReadOnlyJob.Sync(ctx, false)
-	return err
-}
-
-func (m *Master) IsExitReadOnlyDone(ctx context.Context) (bool, error) {
-	err := m.exitReadOnlyJob.Fetch(ctx)
-	if err != nil {
-		return false, err
-	}
-	return m.exitReadOnlyJob.initJob.Completed(), nil
-}
-
 func (m *Master) setMasterReadOnlyExitPrepared(ctx context.Context, status metav1.ConditionStatus) {
 	m.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
 		Type:    consts.ConditionMasterExitReadOnlyPrepared,

--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -7,14 +7,15 @@ import (
 
 	ptr "k8s.io/utils/pointer"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
 	ytv1 "github.com/ytsaurus/yt-k8s-operator/api/v1"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/apiproxy"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/consts"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/labeller"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/resources"
 	"github.com/ytsaurus/yt-k8s-operator/pkg/ytconfig"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // server manages common resources of YTsaurus cluster server components.
@@ -24,6 +25,7 @@ type server interface {
 	podsManager
 	needUpdate() bool
 	needSync() bool
+	needSync2() bool
 	buildStatefulSet() *appsv1.StatefulSet
 	rebuildStatefulSet() *appsv1.StatefulSet
 }

--- a/pkg/components/suite_test.go
+++ b/pkg/components/suite_test.go
@@ -2,16 +2,18 @@ package components
 
 import (
 	"context"
+	"os"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	mock_yt "github.com/ytsaurus/yt-k8s-operator/pkg/mock"
 	"go.ytsaurus.tech/yt/go/yt"
 	appsv1 "k8s.io/api/apps/v1"
-	"os"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
+
+	mock_yt "github.com/ytsaurus/yt-k8s-operator/pkg/mock"
 )
 
 var ctrl *gomock.Controller
@@ -90,6 +92,9 @@ func (fs *FakeServer) podsImageCorrespondsToSpec() bool {
 func (fs *FakeServer) needSync() bool {
 	return false
 }
+func (fs *FakeServer) needSync2() bool {
+	return false
+}
 
 func (fs *FakeServer) arePodsRemoved(ctx context.Context) bool {
 	return true
@@ -139,6 +144,6 @@ func (fyc *FakeYtsaurusClient) SetStatus(status ComponentStatus) {
 	fyc.status = status
 }
 
-func (fc *FakeYtsaurusClient) IsUpdatable() bool {
+func (fyc *FakeYtsaurusClient) IsUpdatable() bool {
 	return false
 }

--- a/pkg/components/ytsaurus_client.go
+++ b/pkg/components/ytsaurus_client.go
@@ -26,11 +26,15 @@ type YtsaurusClient interface {
 	GetYtClient() yt.Client
 	HandlePossibilityCheck(context.Context) (bool, string, error)
 	EnableSafeMode(context.Context) error
+	DisableSafeMode(context.Context) error
 	IsSafeModeEnabled(context.Context) (bool, error)
 	SaveTableCellsAndUpdateState(ctx context.Context) error
 	IsTableCellsSaved() bool
 	RemoveTableCells(context.Context) error
+	RecoverTableCells(context.Context) error
 	AreTabletCellsRemoved(context.Context) (bool, error)
+	AreTabletCellsRecovered(context.Context) (bool, error)
+	IsMasterReadOnly(context.Context) (bool, error)
 }
 
 type ytsaurusClient struct {
@@ -301,12 +305,9 @@ func (yc *ytsaurusClient) handleUpdatingState(ctx context.Context) (ComponentSta
 
 	case ytv1.UpdateStateWaitingForTabletCellsRecovery:
 		if !yc.ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionTabletCellsRecovered) {
-
-			for _, bundle := range yc.ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles {
-				err = CreateTabletCells(ctx, yc.ytClient, bundle.Name, bundle.TabletCellCount)
-				if err != nil {
-					return SimpleStatus(SyncStatusUpdating), err
-				}
+			err = yc.RecoverTableCells(ctx)
+			if err != nil {
+				return SimpleStatus(SyncStatusUpdating), err
 			}
 
 			yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
@@ -320,7 +321,7 @@ func (yc *ytsaurusClient) handleUpdatingState(ctx context.Context) (ComponentSta
 
 	case ytv1.UpdateStateWaitingForSafeModeDisabled:
 		if !yc.ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionSafeModeDisabled) {
-			err := yc.ytClient.SetNode(ctx, ypath.Path("//sys/@enable_safe_mode"), false, nil)
+			err = yc.DisableSafeMode(ctx)
 			if err != nil {
 				return SimpleStatus(SyncStatusUpdating), err
 			}
@@ -418,227 +419,4 @@ func (yc *ytsaurusClient) Sync(ctx context.Context) error {
 
 func (yc *ytsaurusClient) GetYtClient() yt.Client {
 	return yc.ytClient
-}
-
-func (yc *ytsaurusClient) HandlePossibilityCheck(ctx context.Context) (ok bool, msg string, err error) {
-	if !yc.ytsaurus.GetResource().Spec.EnableFullUpdate {
-		msg = "Full update is not enabled"
-		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-			Type:    consts.ConditionNoPossibility,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Update",
-			Message: msg,
-		})
-		return false, msg, nil
-	}
-
-	// Check tablet cell bundles.
-	notGoodBundles, err := GetNotGoodTabletCellBundles(ctx, yc.ytClient)
-
-	if err != nil {
-		return
-	}
-
-	if len(notGoodBundles) > 0 {
-		msg = fmt.Sprintf("Tablet cell bundles (%v) aren't in 'good' health", notGoodBundles)
-		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-			Type:    consts.ConditionNoPossibility,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Update",
-			Message: msg,
-		})
-		return false, msg, nil
-	}
-
-	// Check LVC.
-	lvcCount := 0
-	err = yc.ytClient.GetNode(ctx, ypath.Path("//sys/lost_vital_chunks/@count"), &lvcCount, nil)
-	if err != nil {
-		return
-	}
-
-	if lvcCount > 0 {
-		msg = fmt.Sprintf("There are lost vital chunks: %v", lvcCount)
-		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-			Type:    consts.ConditionNoPossibility,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Update",
-			Message: msg,
-		})
-		return false, msg, nil
-	}
-
-	// Check QMC.
-	qmcCount := 0
-	err = yc.ytClient.GetNode(ctx, ypath.Path("//sys/quorum_missing_chunks/@count"), &qmcCount, nil)
-	if err != nil {
-		return
-	}
-
-	if qmcCount > 0 {
-		msg = fmt.Sprintf("There are quorum missing chunks: %v", qmcCount)
-		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-			Type:    consts.ConditionNoPossibility,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Update",
-			Message: msg,
-		})
-		return false, msg, nil
-	}
-
-	// Check masters.
-	primaryMasterAddresses := make([]string, 0)
-	err = yc.ytClient.ListNode(ctx, ypath.Path("//sys/primary_masters"), &primaryMasterAddresses, nil)
-	if err != nil {
-		return
-	}
-
-	leadingPrimaryMasterCount := 0
-	followingPrimaryMasterCount := 0
-
-	for _, primaryMasterAddress := range primaryMasterAddresses {
-		var hydra MasterHydra
-		err = yc.ytClient.GetNode(
-			ctx,
-			ypath.Path(fmt.Sprintf("//sys/primary_masters/%v/orchid/monitoring/hydra", primaryMasterAddress)),
-			&hydra,
-			nil)
-		if err != nil {
-			return
-		}
-
-		if !hydra.Active {
-			msg = fmt.Sprintf("There is a non-active master: %v", primaryMasterAddresses)
-			yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-				Type:    consts.ConditionNoPossibility,
-				Status:  metav1.ConditionTrue,
-				Reason:  "Update",
-				Message: msg,
-			})
-			return false, msg, nil
-		}
-
-		switch hydra.State {
-		case MasterStateLeading:
-			leadingPrimaryMasterCount += 1
-		case MasterStateFollowing:
-			followingPrimaryMasterCount += 1
-		}
-	}
-
-	if !(leadingPrimaryMasterCount == 1 && followingPrimaryMasterCount+1 == len(primaryMasterAddresses)) {
-		msg = fmt.Sprintf("There is no leader or some peer is not active")
-		yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-			Type:    consts.ConditionNoPossibility,
-			Status:  metav1.ConditionTrue,
-			Reason:  "Update",
-			Message: msg,
-		})
-		return false, msg, nil
-	}
-
-	msg = "Update is possible"
-	yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-		Type:    consts.ConditionHasPossibility,
-		Status:  metav1.ConditionTrue,
-		Reason:  "Update",
-		Message: msg,
-	})
-	return true, "", nil
-}
-
-func (yc *ytsaurusClient) EnableSafeMode(ctx context.Context) error {
-	return yc.ytClient.SetNode(ctx, ypath.Path("//sys/@enable_safe_mode"), true, nil)
-}
-
-func (yc *ytsaurusClient) IsSafeModeEnabled(ctx context.Context) (bool, error) {
-	var isEnabled bool
-	err := yc.ytClient.GetNode(ctx, ypath.Path("//sys/@enable_safe_mode"), isEnabled, nil)
-	return isEnabled, err
-}
-
-func (yc *ytsaurusClient) saveTableCells(ctx context.Context) error {
-	var tabletCellBundles []ytv1.TabletCellBundleInfo
-	err := yc.ytClient.ListNode(
-		ctx,
-		ypath.Path("//sys/tablet_cell_bundles"),
-		&tabletCellBundles,
-		&yt.ListNodeOptions{Attributes: []string{"tablet_cell_count"}})
-
-	if err != nil {
-		return err
-	}
-
-	yc.ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles = tabletCellBundles
-
-	yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-		Type:    consts.ConditionTabletCellsSaved,
-		Status:  metav1.ConditionTrue,
-		Reason:  "Update",
-		Message: "Tablet cells were saved",
-	})
-	return nil
-}
-
-func (yc *ytsaurusClient) SaveTableCellsAndUpdateState(ctx context.Context) error {
-	err := yc.saveTableCells(ctx)
-	if err != nil {
-		return err
-	}
-	return yc.ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateNone)
-}
-
-func (yc *ytsaurusClient) IsTableCellsSaved() bool {
-	// FIXME: is it a good check? What if we have 0 table cells for example?
-	return len(yc.ytsaurus.GetResource().Status.UpdateStatus.TabletCellBundles) != 0
-}
-
-func (yc *ytsaurusClient) RemoveTableCells(ctx context.Context) error {
-	// FIXME: this needs locking or it can't be two reconciler loops in the same time?
-	var tabletCells []string
-	err := yc.ytClient.ListNode(
-		ctx,
-		ypath.Path("//sys/tablet_cells"),
-		&tabletCells,
-		nil)
-
-	if err != nil {
-		return err
-	}
-
-	for _, tabletCell := range tabletCells {
-		err = yc.ytClient.RemoveNode(
-			ctx,
-			ypath.Path(fmt.Sprintf("//sys/tablet_cells/%s", tabletCell)),
-			nil)
-		if err != nil {
-			return err
-		}
-	}
-
-	yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-		Type:    consts.ConditionTabletCellsRemovingStarted,
-		Status:  metav1.ConditionTrue,
-		Reason:  "Update",
-		Message: "Tablet cells removing was started",
-	})
-	return nil
-}
-
-func (yc *ytsaurusClient) AreTabletCellsRemoved(ctx context.Context) (bool, error) {
-	var tabletCells []string
-	err := yc.ytClient.ListNode(
-		ctx,
-		ypath.Path("//sys/tablet_cells"),
-		&tabletCells,
-		nil)
-
-	if err != nil {
-		return false, err
-	}
-
-	if len(tabletCells) != 0 {
-		return false, err
-	}
-	return true, nil
 }

--- a/pkg/components/ytsaurus_client.go
+++ b/pkg/components/ytsaurus_client.go
@@ -189,19 +189,7 @@ func (yc *ytsaurusClient) handleUpdatingState(ctx context.Context) (ComponentSta
 
 	case ytv1.UpdateStateWaitingForSafeModeEnabled:
 		if !yc.ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionSafeModeEnabled) {
-			err := yc.EnableSafeMode(ctx)
-			if err != nil {
-				return SimpleStatus(SyncStatusUpdating), err
-			}
-
-			yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
-				Type:    consts.ConditionSafeModeEnabled,
-				Status:  metav1.ConditionTrue,
-				Reason:  "Update",
-				Message: "Safe mode was enabled",
-			})
-
-			return SimpleStatus(SyncStatusUpdating), nil
+			return SimpleStatus(SyncStatusUpdating), yc.EnableSafeMode(ctx)
 		}
 
 	case ytv1.UpdateStateWaitingForTabletCellsSaving:

--- a/pkg/components/ytsaurus_client.go
+++ b/pkg/components/ytsaurus_client.go
@@ -148,7 +148,7 @@ func (yc *ytsaurusClient) getMasterHydra(ctx context.Context, path string) (Mast
 	return masterHydra, err
 }
 
-func (yc *ytsaurusClient) startBuildMasterSnapshots(ctx context.Context) error {
+func (yc *ytsaurusClient) StartBuildMasterSnapshots(ctx context.Context) error {
 	var err error
 
 	allMastersReadOnly := true
@@ -259,7 +259,7 @@ func (yc *ytsaurusClient) handleUpdatingState(ctx context.Context) (ComponentSta
 			}
 
 			if !yc.ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionSnapshotsBuildingStarted) {
-				if err = yc.startBuildMasterSnapshots(ctx); err != nil {
+				if err = yc.StartBuildMasterSnapshots(ctx); err != nil {
 					return SimpleStatus(SyncStatusUpdating), err
 				}
 

--- a/pkg/components/ytsaurus_client.go
+++ b/pkg/components/ytsaurus_client.go
@@ -22,19 +22,8 @@ import (
 )
 
 type YtsaurusClient interface {
-	Component2
+	Component
 	GetYtClient() yt.Client
-	HandlePossibilityCheck(context.Context) (bool, string, error)
-	EnableSafeMode(context.Context) error
-	DisableSafeMode(context.Context) error
-	IsSafeModeEnabled(context.Context) (bool, error)
-	SaveTableCellsAndUpdateState(ctx context.Context) error
-	IsTableCellsSaved() bool
-	RemoveTableCells(context.Context) error
-	RecoverTableCells(context.Context) error
-	AreTabletCellsRemoved(context.Context) (bool, error)
-	AreTabletCellsRecovered(context.Context) (bool, error)
-	IsMasterReadOnly(context.Context) (bool, error)
 }
 
 type ytsaurusClient struct {
@@ -51,7 +40,7 @@ func NewYtsaurusClient(
 	cfgen *ytconfig.Generator,
 	ytsaurus *apiproxy.Ytsaurus,
 	httpProxy Component,
-) YtsaurusClient {
+) YtsaurusClient2 {
 	resource := ytsaurus.GetResource()
 	l := labeller.Labeller{
 		ObjectMeta:     &resource.ObjectMeta,

--- a/pkg/components/ytsaurus_client.go
+++ b/pkg/components/ytsaurus_client.go
@@ -22,7 +22,7 @@ import (
 )
 
 type YtsaurusClient interface {
-	Component
+	Component2
 	GetYtClient() yt.Client
 }
 


### PR DESCRIPTION
I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en

**Disclaimer**: currently code is in draft state, to reduce possibility of git conflicts i've been adding new files/temporary methods if possible. Code should be moved to the new locations when we agree on implementation.
Ideally, I want this operator new flow feature to be enabled with flag in some config, so it could be independently tested without breaking existing flow, but I haven't figured how to do it yet.

**What we want to achieve here:**
  1. Replace dynamic graph of components deployments with one linear graph.
  2. Remove components dependency on ytsaurus resource update status (top level flow should orchestrate and run component sync only if needed, sync can't happen if other conditions are not ready)
  3. Each iteration of reconciliation loop should try to advance progress one step at a time.

**What has been done:**
  1. [Here](https://github.com/ytsaurus/yt-k8s-operator/pull/118/files#diff-164c1971e9fc47fa873b007c068631b8786c09c8abdf94dca72a56f294b5c9b2R49-R74) we have single list of steps for flow. 
     - Steps can be implemented either as components or as actions. 
     - Each step is checked if it should run (for example "enable safe mode" wouldn't run if conditions like EnableFullUpdate and master's need to rebuild are not satisfied)
     - Each step is checked if it is already been done or not.
  2. components' Status and Sync are not checking ytsaurus status.

**Side effects/things I'm not sure about**
  1. Since ytsaurus resource statuses and conditions become more or less obsolete (i.e. they can still be used for observability in kubectl output, but code doesn't use them for the flow), I've also tried to rewrite code without using conditions. In some places I've replaced checking for condition to checking some path in ytsaurus cluster. It seems more natural and less error-prone to me, but as a downsides: 1) it can create extra load on masters 2) I'm not sure if all of conditions can be checked that way on YT cluster level and suppose we still might need conditions.

TODO:
  - find a way to configure operator with new flag
  - implement sync/status for all components
  - implement scheduler and qt action steps
  - test the full/partial update scenarios
  - check what can be broken in new flow and add test cases for that