### PR TITLE
Do not serialize zero values for quota parameters

### DIFF
--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/test.canondata
@@ -88,10 +88,6 @@
             {
                 path="/yt/hdd1/chunk-store";
                 "medium_name"=nvme;
-                quota=0;
-                "high_watermark"=0;
-                "low_watermark"=0;
-                "disable_writes_watermark"=0;
             };
         ];
         "cache_locations"=[

--- a/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
@@ -97,10 +97,6 @@
             {
                 path="/yt/hdd1/chunk-store";
                 "medium_name"=nvme;
-                quota=0;
-                "high_watermark"=0;
-                "low_watermark"=0;
-                "disable_writes_watermark"=0;
             };
         ];
         "cache_locations"=[

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfig/test.canondata
@@ -93,8 +93,6 @@
             locations=[
                 {
                     path="/yt/hdd2/slots";
-                    "disk_quota"=#;
-                    "disk_usage_watermark"=0;
                     "medium_name"="";
                 };
             ];

--- a/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
@@ -102,8 +102,6 @@
             locations=[
                 {
                     path="/yt/hdd2/slots";
-                    "disk_quota"=#;
-                    "disk_usage_watermark"=0;
                     "medium_name"="";
                 };
             ];

--- a/pkg/ytconfig/node.go
+++ b/pkg/ytconfig/node.go
@@ -22,10 +22,10 @@ const (
 type StoreLocation struct {
 	Path                   string `yson:"path"`
 	MediumName             string `yson:"medium_name"`
-	Quota                  int64  `yson:"quota"`
-	HighWatermark          int64  `yson:"high_watermark"`
-	LowWatermark           int64  `yson:"low_watermark"`
-	DisableWritesWatermark int64  `yson:"disable_writes_watermark"`
+	Quota                  int64  `yson:"quota,omitempty"`
+	HighWatermark          int64  `yson:"high_watermark,omitempty"`
+	LowWatermark           int64  `yson:"low_watermark,omitempty"`
+	DisableWritesWatermark int64  `yson:"disable_writes_watermark,omitempty"`
 }
 
 type ResourceLimits struct {
@@ -40,8 +40,8 @@ type DiskLocation struct {
 
 type SlotLocation struct {
 	Path               string `yson:"path"`
-	DiskQuota          *int64 `yson:"disk_quota"`
-	DiskUsageWatermark int64  `yson:"disk_usage_watermark"`
+	DiskQuota          *int64 `yson:"disk_quota,omitempty"`
+	DiskUsageWatermark int64  `yson:"disk_usage_watermark,omitempty"`
 	MediumName         string `yson:"medium_name"`
 }
 


### PR DESCRIPTION
When quota parameters for locations could not be discovered from the PVC requests, they default to zero, which ytsaurus nodes perceive as a real zero-quota. Instead we prefer not to serialize these config parameters, and rely on the default behavior.

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=en
