### PR TITLE
Add nodeSelector, tolerations, affinity, strategy, issuerRef to the Helm chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -299,12 +299,9 @@ helm-chart: manifests kustomize helmify envsubst yq ## Generate helm chart.
 	sed -e '/replicas:/a\'$$'\n''  strategy: {{- toYaml .Values.controllerManager.strategy | nindent 4 }}' \
 		-e '/nodeSelector:/a\'$$'\n''      tolerations: {{- toYaml .Values.controllerManager.tolerations | nindent 8 }}' \
 		-e '/nodeSelector:/a\'$$'\n''      affinity: {{- toYaml .Values.controllerManager.affinity | nindent 8 }}' \
-		-i '.bak' $(OPERATOR_CHART)/templates/deployment.yaml && \
+		-i.bak $(OPERATOR_CHART)/templates/deployment.yaml && \
 	rm $(OPERATOR_CHART)/templates/deployment.yaml.bak
-	sed -e '1 i\'$$'\n''{{- if not .Values.issuerRef.name }}' \
-		-e '$$a \'$$'\n''\'$$'\n''{{- end }}'  \
-		-i '.bak' $(OPERATOR_CHART)/templates/selfsigned-issuer.yaml && \
-	rm $(OPERATOR_CHART)/templates/selfsigned-issuer.yaml.bak
+	echo -e '{{- if not .Values.issuerRef.name }}\n'"$$(cat $(OPERATOR_CHART)/templates/selfsigned-issuer.yaml)"'\n{{- end }}' > $(OPERATOR_CHART)/templates/selfsigned-issuer.yaml
 	cat config/helm/templates/_helpers.tpl >> $(OPERATOR_CHART)/templates/_helpers.tpl
 	$(YQ) eval-all '. as $$item ireduce ({}; . * $$item )' -i $(OPERATOR_CHART)/values.yaml config/helm/values.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -361,7 +361,7 @@ KIND ?= $(LOCALBIN)/kind-$(KIND_VERSION)
 KUSTOMIZE_VERSION ?= v5.3.0
 CONTROLLER_GEN_VERSION ?= v0.14.0
 ENVTEST_VERSION ?= latest
-HELMIFY_VERSION ?= v0.4.5
+HELMIFY_VERSION ?= v0.4.13
 ## golangci-lint version.
 GOLANGCI_LINT_VERSION ?= v1.56.2
 GINKGO_VERSION ?= $(call go-get-version,github.com/onsi/ginkgo/v2)

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -9,21 +9,21 @@ resources:
 - bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
 #+kubebuilder:scaffold:crdkustomizeresource
 
-patchesStrategicMerge:
+patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
-- patches/webhook_in_ytsaurus.yaml
-- patches/webhook_in_spyts.yaml
-- patches/webhook_in_chyts.yaml
+- path: patches/webhook_in_ytsaurus.yaml
+- path: patches/webhook_in_spyts.yaml
+- path: patches/webhook_in_chyts.yaml
 #- patches/webhook_in_remoteytsauruses.yaml
 #- patches/webhook_in_remoteexecnodes.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
 
 # [CERTMANAGER] To enable cert-manager, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
-- patches/cainjection_in_ytsaurus.yaml
-- patches/cainjection_in_spyts.yaml
-- patches/cainjection_in_chyts.yaml
+- path: patches/cainjection_in_ytsaurus.yaml
+- path: patches/cainjection_in_spyts.yaml
+- path: patches/cainjection_in_chyts.yaml
 #- patches/cainjection_in_remoteytsauruses.yaml
 #- patches/cainjection_in_remoteexecnodes.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/config/crd/patches/cainjection_in_chyts.yaml
+++ b/config/crd/patches/cainjection_in_chyts.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
   name: chyts.cluster.ytsaurus.tech

--- a/config/crd/patches/cainjection_in_remoteexecnodes.yaml
+++ b/config/crd/patches/cainjection_in_remoteexecnodes.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
   name: remoteexecnodes.cluster.ytsaurus.tech

--- a/config/crd/patches/cainjection_in_remoteytsauruses.yaml
+++ b/config/crd/patches/cainjection_in_remoteytsauruses.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
   name: remoteytsauruses.cluster.ytsaurus.tech

--- a/config/crd/patches/cainjection_in_spyts.yaml
+++ b/config/crd/patches/cainjection_in_spyts.yaml
@@ -3,5 +3,5 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+    cert-manager.io/inject-ca-from: $(WEBHOOK_CERTIFICATE_NAMESPACE)/$(WEBHOOK_CERTIFICATE_NAME)
   name: spyts.cluster.ytsaurus.tech

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -8,7 +8,7 @@ namespace: yt-k8s-operator-system
 # field above.
 namePrefix: yt-k8s-operator-
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -20,11 +20,11 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
+- path: manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
@@ -32,12 +32,12 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-- manager_webhook_patch.yaml
+- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-- webhookcainjection_patch.yaml
+- path: webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
@@ -76,7 +76,6 @@ vars:
     kind: Service
     version: v1
     name: webhook-service
-
 - name: METRICS_SECRET_NAME
   objref:
     kind: Certificate

--- a/config/helm/Chart.yaml
+++ b/config/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
-name: ytop-chart
+name: ${name:-ytop-chart}
 description: A Helm chart for Kubernetes
 type: application
-version: "0.0.0-alpha"
-appVersion: "0.0.0-alpha"
+version: "${version:-0.0.0-alpha}"
+appVersion: "${version:-0.0.0-alpha}"
 sources:
   - https://github.com/ytsaurus/yt-k8s-operator

--- a/config/helm/certificate_patch.yaml
+++ b/config/helm/certificate_patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: any
+spec:
+  issuerRef:
+    kind: '{{ .Values.issuerRef.kind }}'
+    name: '{{ include "ytop-chart.issuerRefName" . }}'

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -1,0 +1,7 @@
+resources:
+- ../default
+
+patches:
+  - target:
+      kind: Certificate
+    path: certificate_patch.yaml

--- a/config/helm/templates/_helpers.tpl
+++ b/config/helm/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+
+{{/*
+Expand the name of the cert-manager Issuer.
+*/}}
+{{- define "ytop-chart.issuerRefName" -}}
+{{- default (printf "%s-selfsigned-issuer" (include "ytop-chart.fullname" .)) .Values.issuerRef.name }}
+{{- end }}

--- a/config/helm/values.yaml
+++ b/config/helm/values.yaml
@@ -1,0 +1,8 @@
+controllerManager:
+  strategy:
+    type: RollingUpdate
+  affinity: {}
+  tolerations: []
+issuerRef:
+  kind: Issuer
+  name: ""

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -73,4 +73,6 @@ spec:
             cpu: 10m
             memory: 64Mi
       serviceAccountName: controller-manager
+      nodeSelector: {}
+      tolerations: []
       terminationGracePeriodSeconds: 10

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -17,6 +17,7 @@ spec:
     matchLabels:
       control-plane: controller-manager
   replicas: 1
+  revisionHistoryLimit: 10
   template:
     metadata:
       annotations:

--- a/ytop-chart/templates/_helpers.tpl
+++ b/ytop-chart/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Expand the name of the cert-manager Issuer.
+*/}}
+{{- define "ytop-chart.issuerRefName" -}}
+{{- default (printf "%s-selfsigned-issuer" (include "ytop-chart.fullname" .)) .Values.issuerRef.name }}
+{{- end }}

--- a/ytop-chart/templates/chyt-crd.yaml
+++ b/ytop-chart/templates/chyt-crd.yaml
@@ -4,7 +4,7 @@ metadata:
   name: chyts.cluster.ytsaurus.tech
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "ytop-chart.fullname"
-      . }}-$(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)'
+      . }}-webhook-cert'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
   {{- include "ytop-chart.labels" . | nindent 4 }}

--- a/ytop-chart/templates/deployment.yaml
+++ b/ytop-chart/templates/deployment.yaml
@@ -77,6 +77,7 @@ spec:
         - mountPath: /etc/certs/tls
           name: metrics-cert
           readOnly: true
+      nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "ytop-chart.fullname" . }}-controller-manager

--- a/ytop-chart/templates/deployment.yaml
+++ b/ytop-chart/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- include "ytop-chart.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
+  strategy: {{- toYaml .Values.controllerManager.strategy | nindent 4 }}
   revisionHistoryLimit: {{ .Values.controllerManager.revisionHistoryLimit }}
   selector:
     matchLabels:
@@ -78,6 +79,8 @@ spec:
           name: metrics-cert
           readOnly: true
       nodeSelector: {{- toYaml .Values.controllerManager.nodeSelector | nindent 8 }}
+      tolerations: {{- toYaml .Values.controllerManager.tolerations | nindent 8 }}
+      affinity: {{- toYaml .Values.controllerManager.affinity | nindent 8 }}
       securityContext:
         runAsNonRoot: true
       serviceAccountName: {{ include "ytop-chart.fullname" . }}-controller-manager

--- a/ytop-chart/templates/deployment.yaml
+++ b/ytop-chart/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- include "ytop-chart.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.controllerManager.replicas }}
+  revisionHistoryLimit: {{ .Values.controllerManager.revisionHistoryLimit }}
   selector:
     matchLabels:
       control-plane: controller-manager

--- a/ytop-chart/templates/metrics-cert.yaml
+++ b/ytop-chart/templates/metrics-cert.yaml
@@ -11,6 +11,6 @@ spec:
   - '{{ include "ytop-chart.fullname" . }}-controller-manager-metrics-service.{{ .Release.Namespace
     }}.svc.{{ .Values.kubernetesClusterDomain }}'
   issuerRef:
-    kind: Issuer
-    name: '{{ include "ytop-chart.fullname" . }}-selfsigned-issuer'
+    kind: '{{ .Values.issuerRef.kind }}'
+    name: '{{ include "ytop-chart.issuerRefName" . }}'
   secretName: yt-operator-metrics-cert

--- a/ytop-chart/templates/metrics-service.yaml
+++ b/ytop-chart/templates/metrics-service.yaml
@@ -11,4 +11,4 @@ spec:
     control-plane: controller-manager
   {{- include "ytop-chart.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.metricsService.ports | toYaml | nindent 2 -}}
+	{{- .Values.metricsService.ports | toYaml | nindent 2 }}

--- a/ytop-chart/templates/selfsigned-issuer.yaml
+++ b/ytop-chart/templates/selfsigned-issuer.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.issuerRef.name }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -6,3 +7,4 @@ metadata:
   {{- include "ytop-chart.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
+{{- end }}

--- a/ytop-chart/templates/spyt-crd.yaml
+++ b/ytop-chart/templates/spyt-crd.yaml
@@ -4,7 +4,7 @@ metadata:
   name: spyts.cluster.ytsaurus.tech
   annotations:
     cert-manager.io/inject-ca-from: '{{ .Release.Namespace }}/{{ include "ytop-chart.fullname"
-      . }}-$(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)'
+      . }}-webhook-cert'
     controller-gen.kubebuilder.io/version: v0.14.0
   labels:
   {{- include "ytop-chart.labels" . | nindent 4 }}

--- a/ytop-chart/templates/webhook-cert.yaml
+++ b/ytop-chart/templates/webhook-cert.yaml
@@ -10,6 +10,6 @@ spec:
   - '{{ include "ytop-chart.fullname" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{
     .Values.kubernetesClusterDomain }}'
   issuerRef:
-    kind: Issuer
-    name: '{{ include "ytop-chart.fullname" . }}-selfsigned-issuer'
+    kind: '{{ .Values.issuerRef.kind }}'
+    name: '{{ include "ytop-chart.issuerRefName" . }}'
   secretName: yt-operator-webhook-cert

--- a/ytop-chart/templates/webhook-service.yaml
+++ b/ytop-chart/templates/webhook-service.yaml
@@ -13,4 +13,4 @@ spec:
     control-plane: controller-manager
   {{- include "ytop-chart.selectorLabels" . | nindent 4 }}
   ports:
-	{{- .Values.webhookService.ports | toYaml | nindent 2 -}}
+	{{- .Values.webhookService.ports | toYaml | nindent 2 }}

--- a/ytop-chart/values.yaml
+++ b/ytop-chart/values.yaml
@@ -45,6 +45,7 @@ controllerManager:
       requests:
         cpu: 10m
         memory: 64Mi
+  nodeSelector: {}
   replicas: 1
   revisionHistoryLimit: 10
   serviceAccount:

--- a/ytop-chart/values.yaml
+++ b/ytop-chart/values.yaml
@@ -1,17 +1,17 @@
 controllerManager:
   kubeRbacProxy:
     args:
-    - --secure-listen-address=:8443
-    - --upstream=http://127.0.0.1:8080/
-    - --logtostderr=true
-    - --tls-cert-file=/etc/certs/tls/tls.crt
-    - --tls-private-key-file=/etc/certs/tls/tls.key
-    - --v=0
+      - --secure-listen-address=:8443
+      - --upstream=http://127.0.0.1:8080/
+      - --logtostderr=true
+      - --tls-cert-file=/etc/certs/tls/tls.crt
+      - --tls-private-key-file=/etc/certs/tls/tls.key
+      - --v=0
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - ALL
+          - ALL
     image:
       repository: gcr.io/kubebuilder/kube-rbac-proxy
       tag: v0.13.0
@@ -24,14 +24,14 @@ controllerManager:
         memory: 64Mi
   manager:
     args:
-    - --health-probe-bind-address=:8081
-    - --metrics-bind-address=127.0.0.1:8080
-    - --leader-elect
+      - --health-probe-bind-address=:8081
+      - --metrics-bind-address=127.0.0.1:8080
+      - --leader-elect
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:
         drop:
-        - ALL
+          - ALL
     env:
       watchNamespace: ""
       ytLogLevel: DEBUG
@@ -50,6 +50,10 @@ controllerManager:
   revisionHistoryLimit: 10
   serviceAccount:
     annotations: {}
+  strategy:
+    type: RollingUpdate
+  affinity: {}
+  tolerations: []
 kubernetesClusterDomain: cluster.local
 managerConfig:
   controllerManagerConfigYaml: |-
@@ -76,14 +80,17 @@ managerConfig:
     # leaderElectionReleaseOnCancel: true
 metricsService:
   ports:
-  - name: https
-    port: 8443
-    protocol: TCP
-    targetPort: https
+    - name: https
+      port: 8443
+      protocol: TCP
+      targetPort: https
   type: ClusterIP
 webhookService:
   ports:
-  - port: 443
-    protocol: TCP
-    targetPort: 9443
+    - port: 443
+      protocol: TCP
+      targetPort: 9443
   type: ClusterIP
+issuerRef:
+  kind: Issuer
+  name: ""

--- a/ytop-chart/values.yaml
+++ b/ytop-chart/values.yaml
@@ -46,6 +46,7 @@ controllerManager:
         cpu: 10m
         memory: 64Mi
   replicas: 1
+  revisionHistoryLimit: 10
   serviceAccount:
     annotations: {}
 kubernetesClusterDomain: cluster.local


### PR DESCRIPTION
While `nodeSelector` was supported by `helmify`, other needed fields are not. Thus, ugly sed commands are needed to generate the chart.

Considering this change as a temporary hack, I see this options:
1. Create an issue/PR with support for needed fields in the `helmify` project.
2. Stop generating the chart. Maintain it manually, only copying generated CRDs.
3. Generate the chart with other tools. For instance, https://github.com/yeahdongcn/kustohelmize.
4. Write own tool 😎.