### PR TITLE
Fix empty volumes array in sample config

### DIFF
--- a/config/samples/cluster_v1_cri.yaml
+++ b/config/samples/cluster_v1_cri.yaml
@@ -284,11 +284,11 @@ spec:
         #   mountPath: /config/registry
         #   readOnly: true
 
-      volumes:
-        # - name: config-registry
-        #   hostPath:
-        #     path: /etc/containerd/certs.d
-        #     type: Directory
+      # volumes:
+      #   - name: config-registry
+      #     hostPath:
+      #       path: /etc/containerd/certs.d
+      #       type: Directory
 
       volumeClaimTemplates:
         - metadata:


### PR DESCRIPTION
YAML "volumes:" parsed as "volumes: null" instead "volumes: []".

This breaks server-side apply:

The Ytsaurus "ytsaurus" is invalid:
spec.execNodes[0].volumes:
Invalid value: "null":
spec.execNodes[0].volumes in body must be of type array: "null"
