### PR TITLE
Add observedGeneration field to the YtsaurusStatus

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -734,8 +734,9 @@ type UpdateStatus struct {
 // YtsaurusStatus defines the observed state of Ytsaurus
 type YtsaurusStatus struct {
 	//+kubebuilder:default:=Created
-	State      ClusterState       `json:"state,omitempty"`
-	Conditions []metav1.Condition `json:"conditions,omitempty"`
+	State              ClusterState       `json:"state,omitempty"`
+	Conditions         []metav1.Condition `json:"conditions,omitempty"`
+	ObservedGeneration int64              `json:"observedGeneration,omitempty"`
 
 	UpdateStatus UpdateStatus `json:"updateStatus,omitempty"`
 }

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -37068,6 +37068,9 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               state:
                 default: Created
                 type: string

--- a/controllers/sync.go
+++ b/controllers/sync.go
@@ -530,10 +530,10 @@ func (r *YtsaurusReconciler) Sync(ctx context.Context, resource *ytv1.Ytsaurus) 
 			logger.Info("Ytsaurus has synced and is running now")
 			err := ytsaurus.SaveClusterState(ctx, ytv1.ClusterStateRunning)
 			if err != nil {
-				return ctrl.Result{}, err
+				return ctrl.Result{Requeue: true}, err
 			}
 			err = ytsaurus.SaveObserverGeneration(ctx, resource.ObjectMeta.Generation)
-			return ctrl.Result{}, err
+			return ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.ClusterStateRunning:

--- a/pkg/apiproxy/ytsaurus.go
+++ b/pkg/apiproxy/ytsaurus.go
@@ -115,6 +115,17 @@ func (c *Ytsaurus) SaveClusterState(ctx context.Context, clusterState ytv1.Clust
 	return nil
 }
 
+func (c *Ytsaurus) SaveObserverGeneration(ctx context.Context, generation int64) error {
+	logger := log.FromContext(ctx)
+	c.ytsaurus.Status.ObservedGeneration = generation
+	if err := c.apiProxy.UpdateStatus(ctx); err != nil {
+		logger.Error(err, "unable to update Ytsaurus cluster status")
+		return err
+	}
+
+	return nil
+}
+
 func (c *Ytsaurus) SaveUpdateState(ctx context.Context, updateState ytv1.UpdateState) error {
 	logger := log.FromContext(ctx)
 	c.ytsaurus.Status.UpdateStatus.State = updateState

--- a/pkg/apiproxy/ytsaurus.go
+++ b/pkg/apiproxy/ytsaurus.go
@@ -116,11 +116,9 @@ func (c *Ytsaurus) SaveClusterState(ctx context.Context, clusterState ytv1.Clust
 }
 
 func (c *Ytsaurus) SaveObserverGeneration(ctx context.Context, generation int64) error {
-	logger := log.FromContext(ctx)
 	c.ytsaurus.Status.ObservedGeneration = generation
 	if err := c.apiProxy.UpdateStatus(ctx); err != nil {
-		logger.Error(err, "unable to update Ytsaurus cluster status")
-		return err
+		return fmt.Errorf("failed to save observed generation in status: %w", err)
 	}
 
 	return nil

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -1097,6 +1097,7 @@ func getSimpleUpdateScenario(namespace, newImage string) func(ctx context.Contex
 		DeferCleanup(deleteYtsaurus, ytsaurus)
 		name := types.NamespacedName{Name: ytsaurus.GetName(), Namespace: namespace}
 		deployAndCheck(ytsaurus, namespace)
+		oldGeneration := ytsaurus.ObjectMeta.Generation
 
 		By("Run cluster update")
 		podsBeforeUpdate := getComponentPods(ctx, namespace)
@@ -1119,6 +1120,7 @@ func getSimpleUpdateScenario(namespace, newImage string) func(ctx context.Contex
 		Expect(podDiff.created.IsEmpty()).To(BeTrue(), "unexpected pod diff created %v", podDiff.created)
 		Expect(podDiff.deleted.IsEmpty()).To(BeTrue(), "unexpected pod diff deleted %v", podDiff.deleted)
 		Expect(podDiff.recreated.Equal(NewStringSetFromMap(podsBeforeUpdate))).To(BeTrue(), "unexpected pod diff recreated %v", podDiff.recreated)
+		Expect(ytsaurus.ObjectMeta.Generation).To(Equal(oldGeneration + 1))
 	}
 }
 

--- a/ytop-chart/templates/crds/ytsaurus.cluster.ytsaurus.tech.yaml
+++ b/ytop-chart/templates/crds/ytsaurus.cluster.ytsaurus.tech.yaml
@@ -37079,6 +37079,9 @@ spec:
                   - type
                   type: object
                 type: array
+              observedGeneration:
+                format: int64
+                type: integer
               state:
                 default: Created
                 type: string


### PR DESCRIPTION
To distinguish better between states of YtSaurus while updating we are adding observedGeneration to the YtsurusStatus, so if the Ytsaurus configuration is updated we could easily see it by increased  observedGeneration.

This change resolves the issue #307. 