### PR TITLE
Set statistics for job low cpu usage alerts

### DIFF
--- a/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
@@ -89,5 +89,11 @@
     "controller_agent"={
         "enable_tmpfs"=%true;
         "use_columnar_statistics_default"=%true;
+        "alert_manager"={
+            "low_cpu_usage_alert_statistics"=[
+                "/job/cpu/system";
+                "/job/cpu/user";
+            ];
+        };
     };
 }

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -481,6 +481,11 @@ func (g *Generator) getControllerAgentConfigImpl(spec *ytv1.ControllerAgentsSpec
 	c.ControllerAgent.EnableTmpfs = true
 	c.ControllerAgent.UseColumnarStatisticsDefault = true
 
+	c.ControllerAgent.AlertManager.LowCpuUsageAlertStatisics = []string{
+		"/job/cpu/system",
+		"/job/cpu/user",
+	}
+
 	g.fillCommonService(&c.CommonServer, &spec.InstanceSpec)
 	g.fillBusServer(&c.CommonServer, spec.NativeTransport)
 

--- a/pkg/ytconfig/scheduler.go
+++ b/pkg/ytconfig/scheduler.go
@@ -18,9 +18,15 @@ type SchedulerServer struct {
 	Scheduler Scheduler `yson:"scheduler"`
 }
 
+type AlertManager struct {
+	LowCpuUsageAlertStatisics []string `yson:"low_cpu_usage_alert_statistics,omitempty"`
+}
+
 type ControllerAgent struct {
 	EnableTmpfs                  bool `yson:"enable_tmpfs"`
 	UseColumnarStatisticsDefault bool `yson:"use_columnar_statistics_default"`
+
+	AlertManager AlertManager `yson:"alert_manager"`
 }
 
 type ControllerAgentServer struct {


### PR DESCRIPTION
in cri job-env job-proxy exports "/job/cpu/usage" rather than "/user_job/cpu/user".

https://github.com/ytsaurus/ytsaurus/blob/02299d6d61ddb02fc6b55cba4ef4b30202446391/yt/yt/server/controller_agent/config.cpp#L138

https://github.com/ytsaurus/ytsaurus/blob/02299d6d61ddb02fc6b55cba4ef4b30202446391/yt/yt/server/job_proxy/environment.h#L175

https://github.com/ytsaurus/ytsaurus/blob/02299d6d61ddb02fc6b55cba4ef4b30202446391/yt/yt/server/job_proxy/job_proxy.cpp#L1124