### PR TITLE
Fix RELEASE_VERSION propagation to the image tag

### DIFF
--- a/ytop-chart/values.yaml
+++ b/ytop-chart/values.yaml
@@ -37,7 +37,7 @@ controllerManager:
       ytLogLevel: DEBUG
     image:
       repository: ytsaurus/k8s-operator
-      tag: 0.0.0-alpha
+      tag: ""
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
As mentioned in https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/320#issuecomment-2338444497, I broke tag propagation with my changes in #320.

I verified that propagation with this fix works in this way:
```bash
RELEASE_VERSION=1.1.1 make helm-chart
helm template ytop-chart ytop-chart/ -s templates/deployment.yaml | grep image
        image: ytsaurus/k8s-operator:1.1.1
        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.0
```

cc: @wilwell.
