### PR TITLE
Revert job image override for UI/strawberry

### DIFF
--- a/pkg/components/strawberry_controller.go
+++ b/pkg/components/strawberry_controller.go
@@ -43,6 +43,7 @@ func NewStrawberryController(
 	dataNodes []Component) *StrawberryController {
 	resource := ytsaurus.GetResource()
 
+	// TODO: strawberry has a different image and can't be nil/fallback on CoreImage.
 	image := resource.Spec.CoreImage
 	if resource.Spec.StrawberryController.Image != nil {
 		image = *resource.Spec.StrawberryController.Image
@@ -83,7 +84,7 @@ func NewStrawberryController(
 			ytsaurus.GetResource().Spec.ImagePullSecrets,
 			"user",
 			consts.ClientConfigFileName,
-			getImageWithDefault(resource.Spec.StrawberryController.Image, resource.Spec.CoreImage),
+			resource.Spec.CoreImage,
 			cfgen.GetNativeClientConfig,
 			getTolerationsWithDefault(resource.Spec.StrawberryController.Tolerations, resource.Spec.Tolerations),
 			getNodeSelectorWithDefault(resource.Spec.StrawberryController.NodeSelector, resource.Spec.NodeSelector),
@@ -95,7 +96,7 @@ func NewStrawberryController(
 			resource.Spec.ImagePullSecrets,
 			"cluster",
 			ChytInitClusterJobConfigFileName,
-			getImageWithDefault(resource.Spec.StrawberryController.Image, resource.Spec.CoreImage),
+			resource.Spec.CoreImage,
 			cfgen.GetChytInitClusterConfig,
 			getTolerationsWithDefault(resource.Spec.StrawberryController.Tolerations, resource.Spec.Tolerations),
 			getNodeSelectorWithDefault(resource.Spec.StrawberryController.NodeSelector, resource.Spec.NodeSelector),

--- a/pkg/components/ui.go
+++ b/pkg/components/ui.go
@@ -83,7 +83,7 @@ func NewUI(cfgen *ytconfig.Generator, ytsaurus *apiproxy.Ytsaurus, master Compon
 			resource.Spec.ImagePullSecrets,
 			"default",
 			consts.ClientConfigFileName,
-			getImageWithDefault(resource.Spec.UI.Image, resource.Spec.CoreImage),
+			resource.Spec.CoreImage,
 			cfgen.GetNativeClientConfig,
 			getTolerationsWithDefault(resource.Spec.UI.Tolerations, resource.Spec.Tolerations),
 			getNodeSelectorWithDefault(resource.Spec.UI.NodeSelector, resource.Spec.NodeSelector),


### PR DESCRIPTION
In #336 we've fixed that k8s init jobs would have image consistent with component they configure, but for UI and strawberry component's image doesn't have yt cli and can't be used for job. Therefore reverting that part.

Follow up for https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/336#issuecomment-2348867091