### PR TITLE
Fix strawberry controller image for 2nd job

### DIFF
--- a/pkg/components/strawberry_controller.go
+++ b/pkg/components/strawberry_controller.go
@@ -96,7 +96,7 @@ func NewStrawberryController(
 			resource.Spec.ImagePullSecrets,
 			"cluster",
 			ChytInitClusterJobConfigFileName,
-			resource.Spec.CoreImage,
+			image,
 			cfgen.GetChytInitClusterConfig,
 			getTolerationsWithDefault(resource.Spec.StrawberryController.Tolerations, resource.Spec.Tolerations),
 			getNodeSelectorWithDefault(resource.Spec.StrawberryController.NodeSelector, resource.Spec.NodeSelector),


### PR DESCRIPTION
Fix for https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/344
One job in strawberry requires core image and second one — strawberry image
