### PR TITLE
Fix queue agent init script usage for 24.*

### DIFF
--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -208,6 +208,17 @@ func WithQueryTracker(ytsaurus *ytv1.Ytsaurus) *ytv1.Ytsaurus {
 	return ytsaurus
 }
 
+func WithQueueAgent(ytsaurus *ytv1.Ytsaurus) *ytv1.Ytsaurus {
+	ytsaurus.Spec.QueueAgents = &ytv1.QueueAgentSpec{
+		InstanceSpec: ytv1.InstanceSpec{
+			InstanceCount: 1,
+			// Older version doesn't have /usr/bin/ytserver-queue-agent
+			Image: ptr.To(CoreImageNextVer),
+		},
+	}
+	return ytsaurus
+}
+
 func WithRPCProxies(ytsaurus *ytv1.Ytsaurus) *ytv1.Ytsaurus {
 	ytsaurus.Spec.RPCProxies = []ytv1.RPCProxiesSpec{
 		createRPCProxiesSpec(),

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -632,6 +632,7 @@ var _ = Describe("Basic test for Ytsaurus controller", func() {
 
 			ytsaurus := testutil.CreateBaseYtsaurusResource(namespace)
 			ytsaurus = testutil.WithQueryTracker(ytsaurus)
+			ytsaurus = testutil.WithQueueAgent(ytsaurus)
 
 			g := ytconfig.NewGenerator(ytsaurus, "local")
 


### PR DESCRIPTION
Fix #350
Tested it manually for several versions (23, 24.1 with an old version of script, 24.1 with a new version for script, 24.2, 25).
Didn't add separate e2e for qa for now, just add it to the qt e2e, so qa would be tested somehow at least.
Details are in the issue.