### PR TITLE
Added namespacedScope value to the helm chart

### DIFF
--- a/ytop-chart/templates/deployment.yaml
+++ b/ytop-chart/templates/deployment.yaml
@@ -28,8 +28,10 @@ spec:
         env:
         - name: YT_LOG_LEVEL
           value: {{ quote .Values.controllerManager.manager.env.ytLogLevel }}
+        {{- if .Values.controllerManager.manager.namespacedScope }}
         - name: WATCH_NAMESPACE
-          value: {{ quote .Values.controllerManager.manager.env.watchNamespace }}
+          value: {{ tpl (.Release.Namespace) $ }}
+        {{- end }}
         - name: KUBERNETES_CLUSTER_DOMAIN
           value: {{ quote .Values.kubernetesClusterDomain }}
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag

--- a/ytop-chart/templates/validating-webhook-configuration.yaml
+++ b/ytop-chart/templates/validating-webhook-configuration.yaml
@@ -16,6 +16,11 @@ webhooks:
       path: /validate-cluster-ytsaurus-tech-v1-chyt
   failurePolicy: Fail
   name: vchyt.kb.io
+  {{- if .Values.controllerManager.manager.namespacedScope }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   rules:
   - apiGroups:
     - cluster.ytsaurus.tech
@@ -36,6 +41,11 @@ webhooks:
       path: /validate-cluster-ytsaurus-tech-v1-spyt
   failurePolicy: Fail
   name: vspyt.kb.io
+  {{- if .Values.controllerManager.manager.namespacedScope }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   rules:
   - apiGroups:
     - cluster.ytsaurus.tech
@@ -56,6 +66,11 @@ webhooks:
       path: /validate-cluster-ytsaurus-tech-v1-ytsaurus
   failurePolicy: Fail
   name: vytsaurus.kb.io
+  {{- if .Values.controllerManager.manager.namespacedScope }}
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+  {{- end }}
   rules:
   - apiGroups:
     - cluster.ytsaurus.tech

--- a/ytop-chart/values.yaml
+++ b/ytop-chart/values.yaml
@@ -23,6 +23,7 @@ controllerManager:
         cpu: 5m
         memory: 64Mi
   manager:
+    namespacedScope: false
     args:
       - --health-probe-bind-address=:8081
       - --metrics-bind-address=127.0.0.1:8080


### PR DESCRIPTION
For use cases when we have several YT clusters within one k8s cluster and would like to deploy one yt-operator per each YT cluster, we have to make ValidatingWebhookConfiguration watch only a namespace where YT and operator are deployed.
If the namespaceScoped variable is true, WATCH_NAMESPACE will be equal to the namespace where the operator is deployed and where Ytsaurus and/or remote resources are placed. The same logic is applied for namespaceSelector in ValidatingWebhookConfiguration.