### PR TITLE
Configure yqla mrjob syslibs

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -538,6 +538,11 @@ type StrawberryControllerSpec struct {
 
 type YQLAgentSpec struct {
 	InstanceSpec `json:",inline"`
+
+	// Sets mrjob dynamic library paths in yql agent config.
+	//+kubebuilder:default:=false
+	//+optional
+	ConfigureMrJobDynamicLibraries bool `json:"configureMrJobDynamicLibraries"`
 }
 
 type QueueAgentSpec struct {

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -542,7 +542,7 @@ type YQLAgentSpec struct {
 	// Sets mrjob dynamic library paths in yql agent config.
 	//+kubebuilder:default:=false
 	//+optional
-	ConfigureMrJobDynamicLibraries bool `json:"configureMrJobDynamicLibraries"`
+	ConfigureMrJobSystemLibs bool `json:"configureMrJobSystemLibs"`
 }
 
 type QueueAgentSpec struct {

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -35297,7 +35297,7 @@ spec:
                             type: array
                         type: object
                     type: object
-                  configureMrJobDynamicLibraries:
+                  configureMrJobSystemLibs:
                     default: false
                     description: Sets mrjob dynamic library paths in yql agent config.
                     type: boolean

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -35297,6 +35297,10 @@ spec:
                             type: array
                         type: object
                     type: object
+                  configureMrJobDynamicLibraries:
+                    default: false
+                    description: Sets mrjob dynamic library paths in yql agent config.
+                    type: boolean
                   enableAntiAffinity:
                     description: 'Deprecated: use Affinity.PodAntiAffinity instead.'
                     type: boolean

--- a/docs/api.md
+++ b/docs/api.md
@@ -2152,6 +2152,7 @@ _Appears in:_
 | `setHostnameAsFqdn` _boolean_ | SetHostnameAsFQDN indicates whether to set the hostname as FQDN. | true |  |
 | `terminationGracePeriodSeconds` _integer_ | Optional duration in seconds the pod needs to terminate gracefully. |  |  |
 | `nativeTransport` _[RPCTransportSpec](#rpctransportspec)_ | Component config for native RPC bus transport. |  |  |
+| `configureMrJobDynamicLibraries` _boolean_ | Sets mrjob dynamic library paths in yql agent config. | false |  |
 
 
 #### Ytsaurus

--- a/docs/api.md
+++ b/docs/api.md
@@ -2152,7 +2152,7 @@ _Appears in:_
 | `setHostnameAsFqdn` _boolean_ | SetHostnameAsFQDN indicates whether to set the hostname as FQDN. | true |  |
 | `terminationGracePeriodSeconds` _integer_ | Optional duration in seconds the pod needs to terminate gracefully. |  |  |
 | `nativeTransport` _[RPCTransportSpec](#rpctransportspec)_ | Component config for native RPC bus transport. |  |  |
-| `configureMrJobDynamicLibraries` _boolean_ | Sets mrjob dynamic library paths in yql agent config. | false |  |
+| `configureMrJobSystemLibs` _boolean_ | Sets mrjob dynamic library paths in yql agent config. | false |  |
 
 
 #### Ytsaurus

--- a/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
@@ -112,12 +112,6 @@
                 };
             ];
             "mr_job_system_libs_with_md5"=[
-                {
-                    file="/usr/lib/yql/libiconv.so";
-                };
-                {
-                    file="/usr/lib/yql/liblibidn-dynamic.so";
-                };
             ];
         };
         "yql_plugin_shared_library"="/usr/lib/yql/libyqlplugin.so";

--- a/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
@@ -111,6 +111,14 @@
                     default=%true;
                 };
             ];
+            "mr_job_system_libs_with_md5"=[
+                {
+                    file="/usr/lib/yql/libiconv.so";
+                };
+                {
+                    file="/usr/lib/yql/liblibidn-dynamic.so";
+                };
+            ];
         };
         "yql_plugin_shared_library"="/usr/lib/yql/libyqlplugin.so";
         "yt_token_path"="/usr/yql_agent_token";

--- a/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
@@ -111,8 +111,6 @@
                     default=%true;
                 };
             ];
-            "mr_job_system_libs_with_md5"=[
-            ];
         };
         "yql_plugin_shared_library"="/usr/lib/yql/libyqlplugin.so";
         "yt_token_path"="/usr/yql_agent_token";

--- a/pkg/ytconfig/yql_agent.go
+++ b/pkg/ytconfig/yql_agent.go
@@ -55,13 +55,15 @@ func getYQLAgentServerCarcass(spec *ytv1.YQLAgentSpec) (YQLAgentServer, error) {
 	c.User = "yql_agent"
 
 	c.YQLAgent.GatewayConfig.UDFDirectory = "/usr/lib/yql"
-	c.YQLAgent.GatewayConfig.MrJobSystemLibsWithMd5 = []MrJobSystemLibsWithMd5{
-		MrJobSystemLibsWithMd5{
-			File: "/usr/lib/yql/libiconv.so",
-		},
-		MrJobSystemLibsWithMd5{
-			File: "/usr/lib/yql/liblibidn-dynamic.so",
-		},
+	if spec.ConfigureMrJobDynamicLibraries {
+		c.YQLAgent.GatewayConfig.MrJobSystemLibsWithMd5 = []MrJobSystemLibsWithMd5{
+			MrJobSystemLibsWithMd5{
+				File: "/usr/lib/yql/libiconv.so",
+			},
+			MrJobSystemLibsWithMd5{
+				File: "/usr/lib/yql/liblibidn-dynamic.so",
+			},
+		}
 	}
 	c.YQLAgent.GatewayConfig.MRJobBinary = "/usr/bin/mrjob"
 	c.YQLAgent.YqlPluginSharedLibrary = "/usr/lib/yql/libyqlplugin.so"

--- a/pkg/ytconfig/yql_agent.go
+++ b/pkg/ytconfig/yql_agent.go
@@ -11,10 +11,15 @@ type ClusterMapping struct {
 	Default bool   `yson:"default"`
 }
 
+type MrJobSystemLibsWithMd5 struct {
+	File string `yson:"file"`
+}
+
 type GatewayConfig struct {
-	MRJobBinary    string           `yson:"mr_job_bin"`
-	UDFDirectory   string           `yson:"mr_job_udfs_dir"`
-	ClusterMapping []ClusterMapping `yson:"cluster_mapping"`
+	MRJobBinary            string                   `yson:"mr_job_bin"`
+	UDFDirectory           string                   `yson:"mr_job_udfs_dir"`
+	ClusterMapping         []ClusterMapping         `yson:"cluster_mapping"`
+	MrJobSystemLibsWithMd5 []MrJobSystemLibsWithMd5 `yson:"mr_job_system_libs_with_md5"`
 }
 
 type YQLAgent struct {
@@ -50,6 +55,14 @@ func getYQLAgentServerCarcass(spec *ytv1.YQLAgentSpec) (YQLAgentServer, error) {
 	c.User = "yql_agent"
 
 	c.YQLAgent.GatewayConfig.UDFDirectory = "/usr/lib/yql"
+	c.YQLAgent.GatewayConfig.MrJobSystemLibsWithMd5 = []MrJobSystemLibsWithMd5{
+		MrJobSystemLibsWithMd5{
+			File: "/usr/lib/yql/libiconv.so",
+		},
+		MrJobSystemLibsWithMd5{
+			File: "/usr/lib/yql/liblibidn-dynamic.so",
+		},
+	}
 	c.YQLAgent.GatewayConfig.MRJobBinary = "/usr/bin/mrjob"
 	c.YQLAgent.YqlPluginSharedLibrary = "/usr/lib/yql/libyqlplugin.so"
 

--- a/pkg/ytconfig/yql_agent.go
+++ b/pkg/ytconfig/yql_agent.go
@@ -19,7 +19,7 @@ type GatewayConfig struct {
 	MRJobBinary            string                   `yson:"mr_job_bin"`
 	UDFDirectory           string                   `yson:"mr_job_udfs_dir"`
 	ClusterMapping         []ClusterMapping         `yson:"cluster_mapping"`
-	MrJobSystemLibsWithMd5 []MrJobSystemLibsWithMd5 `yson:"mr_job_system_libs_with_md5"`
+	MrJobSystemLibsWithMd5 []MrJobSystemLibsWithMd5 `yson:"mr_job_system_libs_with_md5,omitempty"`
 }
 
 type YQLAgent struct {

--- a/pkg/ytconfig/yql_agent.go
+++ b/pkg/ytconfig/yql_agent.go
@@ -55,7 +55,7 @@ func getYQLAgentServerCarcass(spec *ytv1.YQLAgentSpec) (YQLAgentServer, error) {
 	c.User = "yql_agent"
 
 	c.YQLAgent.GatewayConfig.UDFDirectory = "/usr/lib/yql"
-	if spec.ConfigureMrJobDynamicLibraries {
+	if spec.ConfigureMrJobSystemLibs {
 		c.YQLAgent.GatewayConfig.MrJobSystemLibsWithMd5 = []MrJobSystemLibsWithMd5{
 			MrJobSystemLibsWithMd5{
 				File: "/usr/lib/yql/libiconv.so",

--- a/ytop-chart/templates/crds/ytsaurus.cluster.ytsaurus.tech.yaml
+++ b/ytop-chart/templates/crds/ytsaurus.cluster.ytsaurus.tech.yaml
@@ -35308,7 +35308,7 @@ spec:
                             type: array
                         type: object
                     type: object
-                  configureMrJobDynamicLibraries:
+                  configureMrJobSystemLibs:
                     default: false
                     description: Sets mrjob dynamic library paths in yql agent config.
                     type: boolean

--- a/ytop-chart/templates/crds/ytsaurus.cluster.ytsaurus.tech.yaml
+++ b/ytop-chart/templates/crds/ytsaurus.cluster.ytsaurus.tech.yaml
@@ -35308,6 +35308,10 @@ spec:
                             type: array
                         type: object
                     type: object
+                  configureMrJobDynamicLibraries:
+                    default: false
+                    description: Sets mrjob dynamic library paths in yql agent config.
+                    type: boolean
                   enableAntiAffinity:
                     description: 'Deprecated: use Affinity.PodAntiAffinity instead.'
                     type: boolean


### PR DESCRIPTION
This code is incompatible with old QueryTracker images. Before this we have not supported this options in yqla config.

Also current nightly QueryTracker images are broken without this changes. It is the easiest way to fix them.

That means that new k8s release will only be compatible with new QT release. And this should be specified in release notes.