### PR TITLE
Fix ginkgo filter tests in GHA

### DIFF
--- a/.github/workflows/pr_test_e2e_other.yaml
+++ b/.github/workflows/pr_test_e2e_other.yaml
@@ -8,4 +8,4 @@ jobs:
     name: Run e2e tests for extra scenarios
     uses: ./.github/workflows/subflow_run_e2e_tests.yaml
     with:
-      e2e_filter: "!basic"
+      e2e_filter: "!basic && !selector"

--- a/.github/workflows/pr_test_e2e_selector.yaml
+++ b/.github/workflows/pr_test_e2e_selector.yaml
@@ -1,0 +1,11 @@
+name: Run selector e2e tests
+
+on:
+  pull_request:
+
+jobs:
+  check:
+    name: Run e2e tests for update selector scenarios
+    uses: ./.github/workflows/subflow_run_e2e_tests.yaml
+    with:
+      e2e_filter: "selector"

--- a/Makefile
+++ b/Makefile
@@ -68,9 +68,6 @@ DEBUG =
 ## Tests parallelism.
 GINKGO_PROCS ?= 2
 
-## Filter tests by labels.
-GINKGO_LABEL_FILTER =
-
 GINKGO_FLAGS += --vv
 GINKGO_FLAGS += --trace
 GINKGO_FLAGS += --procs="$(GINKGO_PROCS)"

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -298,7 +298,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				})
 			},
 			Entry("When update Ytsaurus within same major version", Label("basic"), testutil.CoreImageSecond),
-			Entry("When update Ytsaurus to the next major version", testutil.CoreImageNextVer),
+			Entry("When update Ytsaurus to the next major version", Label("basic"), testutil.CoreImageNextVer),
 		)
 
 		Context("Test UpdateSelector", Label("selector"), func() {
@@ -376,7 +376,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				Expect(pods.Updated).To(ConsistOf("tnd-0", "tnd-1", "tnd-2"), "updated")
 			})
 
-			It("Should be updated according to UpdateSelector=MasterOnly,StatelessOnly", Label("basic"), func(ctx context.Context) {
+			It("Should be updated according to UpdateSelector=MasterOnly,StatelessOnly", func(ctx context.Context) {
 
 				By("Run cluster update with selector:MasterOnly")
 				ytsaurus.Spec.UpdateSelector = ytv1.UpdateSelectorMasterOnly
@@ -592,7 +592,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				ytsaurus = testutil.WithQueryTracker(ytsaurus)
 			})
 
-			It("Should run with query tracker and check that query tracker rpc address set up correctly", Label("basic"), func(ctx context.Context) {
+			It("Should run with query tracker and check that query tracker rpc address set up correctly", func(ctx context.Context) {
 				By("Check that query tracker channel exists in cluster_connection")
 				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/@cluster_connection/query_tracker/stages/production/channel"), nil)).Should(BeTrue())
 			})
@@ -605,7 +605,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				ytsaurus = testutil.WithYqlAgent(ytsaurus)
 			})
 
-			It("Should run with yql agent and check that yql agent channel options set up correctly", Label("basic"), func(ctx context.Context) {
+			It("Should run with yql agent and check that yql agent channel options set up correctly", func(ctx context.Context) {
 				By("Creating ytsaurus client")
 				ytClient := createYtsaurusClient(ytsaurus, namespace)
 
@@ -624,7 +624,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				ytsaurus = testutil.WithQueueAgent(ytsaurus)
 			})
 
-			It("Should run with query tracker and check that access control objects set up correctly", Label("basic"), func(ctx context.Context) {
+			It("Should run with query tracker and check that access control objects set up correctly", func(ctx context.Context) {
 
 				By("Check that access control object namespace 'queries' exists")
 				Expect(ytClient.NodeExists(ctx, ypath.Path("//sys/access_control_object_namespaces/queries"), nil)).Should(BeTrue())


### PR DESCRIPTION
Currently both workflows run full set of tests.
Also added third workflow, so we have bit more parallelism. I expect each wf to run around 15 min instead 30+ we have now.