### PR TITLE
Master updates pods after the other components

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -747,6 +747,8 @@ const (
 	UpdateStateWaitingForYqlaUpdatingPrepare      UpdateState = "WaitingForYqlaUpdatingPrepare"
 	UpdateStateWaitingForYqlaUpdate               UpdateState = "WaitingForYqlaUpdate"
 	UpdateStateWaitingForSafeModeDisabled         UpdateState = "WaitingForSafeModeDisabled"
+	UpdateStateWaitingForMasterPodsRemoval        UpdateState = "WaitingForMasterPodsRemoval"
+	UpdateStateWaitingForMasterPodsCreation       UpdateState = "WaitingForMasterPodsCreation"
 )
 
 type TabletCellBundleInfo struct {

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -737,6 +737,8 @@ const (
 	UpdateStateWaitingForSnapshots                UpdateState = "WaitingForSnapshots"
 	UpdateStateWaitingForPodsRemoval              UpdateState = "WaitingForPodsRemoval"
 	UpdateStateWaitingForPodsCreation             UpdateState = "WaitingForPodsCreation"
+	UpdateStateWaitingForMasterPodsRemoval        UpdateState = "WaitingForMasterPodsRemoval"
+	UpdateStateWaitingForMasterPodsCreation       UpdateState = "WaitingForMasterPodsCreation"
 	UpdateStateWaitingForMasterExitReadOnly       UpdateState = "WaitingForMasterExitReadOnly"
 	UpdateStateWaitingForEnableRealChunkLocations UpdateState = "WaitingForEnableRealChunkLocations"
 	UpdateStateWaitingForTabletCellsRecovery      UpdateState = "WaitingForTabletCellsRecovery"
@@ -747,8 +749,6 @@ const (
 	UpdateStateWaitingForYqlaUpdatingPrepare      UpdateState = "WaitingForYqlaUpdatingPrepare"
 	UpdateStateWaitingForYqlaUpdate               UpdateState = "WaitingForYqlaUpdate"
 	UpdateStateWaitingForSafeModeDisabled         UpdateState = "WaitingForSafeModeDisabled"
-	UpdateStateWaitingForMasterPodsRemoval        UpdateState = "WaitingForMasterPodsRemoval"
-	UpdateStateWaitingForMasterPodsCreation       UpdateState = "WaitingForMasterPodsCreation"
 )
 
 type TabletCellBundleInfo struct {

--- a/controllers/sync.go
+++ b/controllers/sync.go
@@ -113,7 +113,7 @@ func (r *YtsaurusReconciler) handleEverything(
 		}
 
 	case ytv1.UpdateStateWaitingForMasterPodsCreation:
-		if componentManager.nonMasterReadyOrUpdating() {
+		if componentManager.masterReadyOrUpdating() {
 			ytsaurus.LogUpdate(ctx, "Master was recreated")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterExitReadOnly)
 			return &ctrl.Result{RequeueAfter: time.Second * 7}, err
@@ -349,7 +349,7 @@ func (r *YtsaurusReconciler) handleMasterOnly(
 		}
 
 	case ytv1.UpdateStateWaitingForMasterPodsCreation:
-		if componentManager.nonMasterReadyOrUpdating() {
+		if componentManager.masterReadyOrUpdating() {
 			ytsaurus.LogUpdate(ctx, "Master was recreated")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterExitReadOnly)
 			return &ctrl.Result{RequeueAfter: time.Second * 7}, err

--- a/controllers/sync.go
+++ b/controllers/sync.go
@@ -80,27 +80,41 @@ func (r *YtsaurusReconciler) handleEverything(
 		// data nodes are re-registered in master after this job, so I've added it only here.
 		if ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionRealChunkLocationsEnabled) {
 			ytsaurus.LogUpdate(ctx, "Real chunk locations enabled")
-			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForSnapshots)
-			return &ctrl.Result{Requeue: true}, err
-		}
-
-	case ytv1.UpdateStateWaitingForSnapshots:
-		if ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionSnaphotsSaved) {
-			ytsaurus.LogUpdate(ctx, "Waiting for pods removal")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsRemoval)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.UpdateStateWaitingForPodsRemoval:
-		if componentManager.arePodsRemoved() {
-			ytsaurus.LogUpdate(ctx, "Waiting for pods creation")
+		if componentManager.areNonMasterPodsRemoved() {
+			ytsaurus.LogUpdate(ctx, "Waiting for non-master pods creation")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsCreation)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.UpdateStateWaitingForPodsCreation:
-		if componentManager.allReadyOrUpdating() {
-			ytsaurus.LogUpdate(ctx, "All components were recreated")
+		if componentManager.nonMasterReadyOrUpdating() {
+			ytsaurus.LogUpdate(ctx, "Non master components were recreated")
+			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForSnapshots)
+			return &ctrl.Result{RequeueAfter: time.Second * 7}, err
+		}
+
+	case ytv1.UpdateStateWaitingForSnapshots:
+		if ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionSnaphotsSaved) {
+			ytsaurus.LogUpdate(ctx, "Waiting for master pods removal")
+			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterPodsRemoval)
+			return &ctrl.Result{Requeue: true}, err
+		}
+
+	case ytv1.UpdateStateWaitingForMasterPodsRemoval:
+		if componentManager.areMasterPodsRemoved() {
+			ytsaurus.LogUpdate(ctx, "Waiting for pods master creation")
+			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterPodsCreation)
+			return &ctrl.Result{Requeue: true}, err
+		}
+
+	case ytv1.UpdateStateWaitingForMasterPodsCreation:
+		if componentManager.nonMasterReadyOrUpdating() {
+			ytsaurus.LogUpdate(ctx, "Master was recreated")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterExitReadOnly)
 			return &ctrl.Result{RequeueAfter: time.Second * 7}, err
 		}
@@ -204,14 +218,14 @@ func (r *YtsaurusReconciler) handleStateless(
 		return &ctrl.Result{Requeue: true}, err
 
 	case ytv1.UpdateStateWaitingForPodsRemoval:
-		if componentManager.arePodsRemoved() {
+		if componentManager.areNonMasterPodsRemoved() {
 			ytsaurus.LogUpdate(ctx, "Waiting for pods creation")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsCreation)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.UpdateStateWaitingForPodsCreation:
-		if componentManager.allReadyOrUpdating() {
+		if componentManager.nonMasterReadyOrUpdating() {
 			ytsaurus.LogUpdate(ctx, "All components were recreated")
 			ytsaurus.LogUpdate(ctx, "Waiting for operations archive prepare for updating")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForOpArchiveUpdatingPrepare)
@@ -327,16 +341,16 @@ func (r *YtsaurusReconciler) handleMasterOnly(
 			return &ctrl.Result{Requeue: true}, err
 		}
 
-	case ytv1.UpdateStateWaitingForPodsRemoval:
-		if componentManager.arePodsRemoved() {
-			ytsaurus.LogUpdate(ctx, "Waiting for pods creation")
-			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsCreation)
+	case ytv1.UpdateStateWaitingForMasterPodsRemoval:
+		if componentManager.areMasterPodsRemoved() {
+			ytsaurus.LogUpdate(ctx, "Waiting for pods master creation")
+			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterPodsCreation)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
-	case ytv1.UpdateStateWaitingForPodsCreation:
-		if componentManager.allReadyOrUpdating() {
-			ytsaurus.LogUpdate(ctx, "All components were recreated")
+	case ytv1.UpdateStateWaitingForMasterPodsCreation:
+		if componentManager.nonMasterReadyOrUpdating() {
+			ytsaurus.LogUpdate(ctx, "Master was recreated")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterExitReadOnly)
 			return &ctrl.Result{RequeueAfter: time.Second * 7}, err
 		}
@@ -411,14 +425,14 @@ func (r *YtsaurusReconciler) handleTabletNodesOnly(
 		}
 
 	case ytv1.UpdateStateWaitingForPodsRemoval:
-		if componentManager.arePodsRemoved() {
+		if componentManager.areNonMasterPodsRemoved() {
 			ytsaurus.LogUpdate(ctx, "Waiting for pods creation")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsCreation)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.UpdateStateWaitingForPodsCreation:
-		if componentManager.allReadyOrUpdating() {
+		if componentManager.nonMasterReadyOrUpdating() {
 			ytsaurus.LogUpdate(ctx, "All components were recreated")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForTabletCellsRecovery)
 			return &ctrl.Result{RequeueAfter: time.Second * 7}, err

--- a/controllers/sync.go
+++ b/controllers/sync.go
@@ -337,7 +337,7 @@ func (r *YtsaurusReconciler) handleMasterOnly(
 	case ytv1.UpdateStateWaitingForSnapshots:
 		if ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionSnaphotsSaved) {
 			ytsaurus.LogUpdate(ctx, "Waiting for pods removal")
-			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsRemoval)
+			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterPodsRemoval)
 			return &ctrl.Result{Requeue: true}, err
 		}
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -797,6 +797,8 @@ _Appears in:_
 | `setHostnameAsFqdn` _boolean_ | SetHostnameAsFQDN indicates whether to set the hostname as FQDN. | true |  |
 | `terminationGracePeriodSeconds` _integer_ | Optional duration in seconds the pod needs to terminate gracefully. |  |  |
 | `nativeTransport` _[RPCTransportSpec](#rpctransportspec)_ | Component config for native RPC bus transport. |  |  |
+| `dnsConfig` _[PodDNSConfig](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#poddnsconfig-v1-core)_ | DNSConfig allows customizing the DNS settings for the pods. |  |  |
+| `dnsPolicy` _[DNSPolicy](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#dnspolicy-v1-core)_ |  |  |  |
 | `serviceType` _[ServiceType](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#servicetype-v1-core)_ |  |  |  |
 | `role` _string_ |  | default | MinLength: 1 <br /> |
 
@@ -2170,6 +2172,8 @@ _Appears in:_
 | `WaitingForSnapshots` |  |
 | `WaitingForPodsRemoval` |  |
 | `WaitingForPodsCreation` |  |
+| `WaitingForMasterPodsRemoval` |  |
+| `WaitingForMasterPodsCreation` |  |
 | `WaitingForMasterExitReadOnly` |  |
 | `WaitingForEnableRealChunkLocations` |  |
 | `WaitingForTabletCellsRecovery` |  |

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -329,7 +329,7 @@ func (m *Master) doSync(ctx context.Context, dry bool) (ComponentStatus, error) 
 		if m.ytsaurus.GetUpdateState() == ytv1.UpdateStateWaitingForEnableRealChunkLocations {
 			return m.restartEnableRealChunksJob(ctx, dry)
 		}
-		if status, err := handleUpdatingClusterState(ctx, m.ytsaurus, m, &m.localComponent, m.server, dry); status != nil {
+		if status, err := handleUpdatingClusterStateForMaster(ctx, m.ytsaurus, m, &m.localComponent, m.server, dry); status != nil {
 			return *status, err
 		}
 	}


### PR DESCRIPTION
It is done to support seamless ux for updating to ytsaurus 24.2.
With this change full update flow will go like that:
- setting enable real chunks flag
- updating all the components (including data nodes restart)
- master makes snapshots
- master pods are updated

That way datanodes will be correctly re-registered before master snapshots are taken and snapshot would be compatible with 24.2 master code.