### PR TITLE
Revert "Master updates pods after the other components"

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -737,8 +737,6 @@ const (
 	UpdateStateWaitingForSnapshots                UpdateState = "WaitingForSnapshots"
 	UpdateStateWaitingForPodsRemoval              UpdateState = "WaitingForPodsRemoval"
 	UpdateStateWaitingForPodsCreation             UpdateState = "WaitingForPodsCreation"
-	UpdateStateWaitingForMasterPodsRemoval        UpdateState = "WaitingForMasterPodsRemoval"
-	UpdateStateWaitingForMasterPodsCreation       UpdateState = "WaitingForMasterPodsCreation"
 	UpdateStateWaitingForMasterExitReadOnly       UpdateState = "WaitingForMasterExitReadOnly"
 	UpdateStateWaitingForEnableRealChunkLocations UpdateState = "WaitingForEnableRealChunkLocations"
 	UpdateStateWaitingForTabletCellsRecovery      UpdateState = "WaitingForTabletCellsRecovery"

--- a/controllers/sync.go
+++ b/controllers/sync.go
@@ -80,41 +80,27 @@ func (r *YtsaurusReconciler) handleEverything(
 		// data nodes are re-registered in master after this job, so I've added it only here.
 		if ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionRealChunkLocationsEnabled) {
 			ytsaurus.LogUpdate(ctx, "Real chunk locations enabled")
+			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForSnapshots)
+			return &ctrl.Result{Requeue: true}, err
+		}
+
+	case ytv1.UpdateStateWaitingForSnapshots:
+		if ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionSnaphotsSaved) {
+			ytsaurus.LogUpdate(ctx, "Waiting for pods removal")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsRemoval)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.UpdateStateWaitingForPodsRemoval:
-		if componentManager.areNonMasterPodsRemoved() {
-			ytsaurus.LogUpdate(ctx, "Waiting for non-master pods creation")
+		if componentManager.arePodsRemoved() {
+			ytsaurus.LogUpdate(ctx, "Waiting for pods creation")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsCreation)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.UpdateStateWaitingForPodsCreation:
-		if componentManager.nonMasterReadyOrUpdating() {
-			ytsaurus.LogUpdate(ctx, "Non master components were recreated")
-			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForSnapshots)
-			return &ctrl.Result{RequeueAfter: time.Second * 7}, err
-		}
-
-	case ytv1.UpdateStateWaitingForSnapshots:
-		if ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionSnaphotsSaved) {
-			ytsaurus.LogUpdate(ctx, "Waiting for master pods removal")
-			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterPodsRemoval)
-			return &ctrl.Result{Requeue: true}, err
-		}
-
-	case ytv1.UpdateStateWaitingForMasterPodsRemoval:
-		if componentManager.areMasterPodsRemoved() {
-			ytsaurus.LogUpdate(ctx, "Waiting for pods master creation")
-			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterPodsCreation)
-			return &ctrl.Result{Requeue: true}, err
-		}
-
-	case ytv1.UpdateStateWaitingForMasterPodsCreation:
-		if componentManager.masterReadyOrUpdating() {
-			ytsaurus.LogUpdate(ctx, "Master was recreated")
+		if componentManager.allReadyOrUpdating() {
+			ytsaurus.LogUpdate(ctx, "All components were recreated")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterExitReadOnly)
 			return &ctrl.Result{RequeueAfter: time.Second * 7}, err
 		}
@@ -218,14 +204,14 @@ func (r *YtsaurusReconciler) handleStateless(
 		return &ctrl.Result{Requeue: true}, err
 
 	case ytv1.UpdateStateWaitingForPodsRemoval:
-		if componentManager.areNonMasterPodsRemoved() {
+		if componentManager.arePodsRemoved() {
 			ytsaurus.LogUpdate(ctx, "Waiting for pods creation")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsCreation)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.UpdateStateWaitingForPodsCreation:
-		if componentManager.nonMasterReadyOrUpdating() {
+		if componentManager.allReadyOrUpdating() {
 			ytsaurus.LogUpdate(ctx, "All components were recreated")
 			ytsaurus.LogUpdate(ctx, "Waiting for operations archive prepare for updating")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForOpArchiveUpdatingPrepare)
@@ -337,20 +323,20 @@ func (r *YtsaurusReconciler) handleMasterOnly(
 	case ytv1.UpdateStateWaitingForSnapshots:
 		if ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionSnaphotsSaved) {
 			ytsaurus.LogUpdate(ctx, "Waiting for pods removal")
-			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterPodsRemoval)
+			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsRemoval)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
-	case ytv1.UpdateStateWaitingForMasterPodsRemoval:
-		if componentManager.areMasterPodsRemoved() {
-			ytsaurus.LogUpdate(ctx, "Waiting for pods master creation")
-			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterPodsCreation)
+	case ytv1.UpdateStateWaitingForPodsRemoval:
+		if componentManager.arePodsRemoved() {
+			ytsaurus.LogUpdate(ctx, "Waiting for pods creation")
+			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsCreation)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
-	case ytv1.UpdateStateWaitingForMasterPodsCreation:
-		if componentManager.masterReadyOrUpdating() {
-			ytsaurus.LogUpdate(ctx, "Master was recreated")
+	case ytv1.UpdateStateWaitingForPodsCreation:
+		if componentManager.allReadyOrUpdating() {
+			ytsaurus.LogUpdate(ctx, "All components were recreated")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForMasterExitReadOnly)
 			return &ctrl.Result{RequeueAfter: time.Second * 7}, err
 		}
@@ -425,14 +411,14 @@ func (r *YtsaurusReconciler) handleTabletNodesOnly(
 		}
 
 	case ytv1.UpdateStateWaitingForPodsRemoval:
-		if componentManager.areNonMasterPodsRemoved() {
+		if componentManager.arePodsRemoved() {
 			ytsaurus.LogUpdate(ctx, "Waiting for pods creation")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForPodsCreation)
 			return &ctrl.Result{Requeue: true}, err
 		}
 
 	case ytv1.UpdateStateWaitingForPodsCreation:
-		if componentManager.nonMasterReadyOrUpdating() {
+		if componentManager.allReadyOrUpdating() {
 			ytsaurus.LogUpdate(ctx, "All components were recreated")
 			err := ytsaurus.SaveUpdateState(ctx, ytv1.UpdateStateWaitingForTabletCellsRecovery)
 			return &ctrl.Result{RequeueAfter: time.Second * 7}, err

--- a/docs/api.md
+++ b/docs/api.md
@@ -2172,8 +2172,6 @@ _Appears in:_
 | `WaitingForSnapshots` |  |
 | `WaitingForPodsRemoval` |  |
 | `WaitingForPodsCreation` |  |
-| `WaitingForMasterPodsRemoval` |  |
-| `WaitingForMasterPodsCreation` |  |
 | `WaitingForMasterExitReadOnly` |  |
 | `WaitingForEnableRealChunkLocations` |  |
 | `WaitingForTabletCellsRecovery` |  |

--- a/pkg/components/helpers.go
+++ b/pkg/components/helpers.go
@@ -150,59 +150,17 @@ func handleUpdatingClusterState(
 	server server,
 	dry bool,
 ) (*ComponentStatus, error) {
-	return handleUpdatingClusterStateForUpdateStates(
-		ctx,
-		ytsaurus,
-		cmp,
-		cmpBase,
-		server,
-		dry,
-		ytv1.UpdateStateWaitingForPodsRemoval,
-		ytv1.UpdateStateWaitingForPodsCreation,
-	)
-}
-
-func handleUpdatingClusterStateForMaster(
-	ctx context.Context,
-	ytsaurus *apiproxy.Ytsaurus,
-	cmp Component,
-	cmpBase *localComponent,
-	server server,
-	dry bool,
-) (*ComponentStatus, error) {
-	return handleUpdatingClusterStateForUpdateStates(
-		ctx,
-		ytsaurus,
-		cmp,
-		cmpBase,
-		server,
-		dry,
-		ytv1.UpdateStateWaitingForMasterPodsRemoval,
-		ytv1.UpdateStateWaitingForMasterPodsCreation,
-	)
-}
-
-func handleUpdatingClusterStateForUpdateStates(
-	ctx context.Context,
-	ytsaurus *apiproxy.Ytsaurus,
-	cmp Component,
-	cmpBase *localComponent,
-	server server,
-	dry bool,
-	podsRemovalState ytv1.UpdateState,
-	podsCreationState ytv1.UpdateState,
-) (*ComponentStatus, error) {
 	var err error
 
 	if IsUpdatingComponent(ytsaurus, cmp) {
-		if ytsaurus.GetUpdateState() == podsRemovalState {
+		if ytsaurus.GetUpdateState() == ytv1.UpdateStateWaitingForPodsRemoval {
 			if !dry {
 				err = removePods(ctx, server, cmpBase)
 			}
 			return ptr.To(WaitingStatus(SyncStatusUpdating, "pods removal")), err
 		}
 
-		if ytsaurus.GetUpdateState() != podsCreationState {
+		if ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForPodsCreation {
 			return ptr.To(NewComponentStatus(SyncStatusReady, "Nothing to do now")), err
 		}
 	} else {

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -329,7 +329,7 @@ func (m *Master) doSync(ctx context.Context, dry bool) (ComponentStatus, error) 
 		if m.ytsaurus.GetUpdateState() == ytv1.UpdateStateWaitingForEnableRealChunkLocations {
 			return m.restartEnableRealChunksJob(ctx, dry)
 		}
-		if status, err := handleUpdatingClusterStateForMaster(ctx, m.ytsaurus, m, &m.localComponent, m.server, dry); status != nil {
+		if status, err := handleUpdatingClusterState(ctx, m.ytsaurus, m, &m.localComponent, m.server, dry); status != nil {
 			return *status, err
 		}
 	}


### PR DESCRIPTION
Reverts ytsaurus/ytsaurus-k8s-operator#437
Patch doesn't help to update to 24.2 because data nodes still registered online at the master even when their pods are recreated.