### PR TITLE
Add config for kind with audit log

### DIFF
--- a/config/kind/audit-policy.yaml
+++ b/config/kind/audit-policy.yaml
@@ -1,0 +1,7 @@
+# https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/
+
+apiVersion: audit.k8s.io/v1
+kind: Policy
+rules:
+# - level: Metadata
+  - level: RequestResponse

--- a/config/kind/kind-with-audit.yaml
+++ b/config/kind/kind-with-audit.yaml
@@ -1,0 +1,90 @@
+# https://kind.sigs.k8s.io/docs/user/configuration/
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+
+# overriden by environment KIND_CLUSTER_NAME
+name: kind
+
+# https://kind.sigs.k8s.io/docs/user/configuration/#networking
+networking:
+# ipFamily: dual
+# ipFamily: ipv6
+# podSubnet: "10.244.0.0/16"
+# serviceSubnet: "10.96.0.0/12"
+# disableDefaultCNI: true
+# kubeProxyMode: "ipvs"
+# kubeProxyMode: "none"
+
+runtimeConfig:
+# "api/alpha": "true"
+
+# https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/
+featureGates:
+# "KubeletCgroupDriverFromCRI": true
+# "NewVolumeManagerReconstruction": true
+# "InPlacePodVerticalScaling": true
+# "MemoryQoS": true
+# "CustomCPUCFSQuotaPeriod": true
+# "StatefulSetStartOrdinal": true
+# "StatefulSetAutoDeletePVC": true
+
+# https://kind.sigs.k8s.io/docs/user/local-registry/
+# https://github.com/containerd/containerd/blob/main/docs/hosts.md
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      config_path = "/etc/containerd/certs.d"
+
+# https://kind.sigs.k8s.io/docs/user/configuration/#nodes
+nodes:
+- role: control-plane
+  # https://kind.sigs.k8s.io/docs/user/configuration#kubeadm-config-patches
+  # https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/control-plane-flags/#etcd-flags
+  # https://etcd.io/docs/v3.5/op-guide/configuration/#command-line-flags
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    etcd:
+      local:
+        extraArgs:
+          unsafe-no-fsync: "true"
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        # enable auditing flags on the API server
+        # https://kind.sigs.k8s.io/docs/user/auditing/
+        # https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/
+        extraArgs:
+          audit-policy-file: /etc/kubernetes/policies/audit-policy.yaml
+          audit-log-path: /var/log/kubernetes/audit-log.json
+          audit-log-maxsize: "256" # MiB
+          audit-log-maxage: "10" # days
+          audit-log-maxbackup: "100" # files
+          audit-log-compress: "true"
+        # mount new files / directories on the control plane
+        extraVolumes:
+          - name: audit-policies
+            hostPath: /etc/kubernetes/policies
+            mountPath: /etc/kubernetes/policies
+            readOnly: true
+            pathType: "DirectoryOrCreate"
+          - name: "audit-logs"
+            hostPath: "/var/log/kubernetes"
+            mountPath: "/var/log/kubernetes"
+            readOnly: false
+            pathType: DirectoryOrCreate
+  extraMounts:
+  - &registry-config
+    hostPath: "config/registry"
+    containerPath: "/etc/containerd/certs.d"
+    readOnly: true
+  - hostPath: "config/kind/audit-policy.yaml"
+    containerPath: /etc/kubernetes/policies/audit-policy.yaml
+    readOnly: true
+  - hostPath: "log/kubernetes"
+    containerPath: "/var/log/kubernetes"
+    readOnly: false
+- role: worker
+  extraMounts:
+  - *registry-config


### PR DESCRIPTION
Usage: make kind-create-cluster KIND_CLUSTER_CONFIG=config/kind/kind-with-audit.yaml

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
