### PR TITLE
Switch to different update trigger in e2e

### DIFF
--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -74,6 +74,6 @@ func updateSpecToTriggerAllComponentUpdate(ytsaurus *ytv1.Ytsaurus) {
 	if ytsaurus.Spec.ForceTCP == nil {
 		ytsaurus.Spec.ForceTCP = ptr.To(true)
 	} else {
-		ytsaurus.Spec.ForceTCP = nil
+		ytsaurus.Spec.ForceTCP = ptr.To(!*ytsaurus.Spec.ForceTCP)
 	}
 }

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -7,7 +7,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/utils/ptr"
 	ctrlcli "sigs.k8s.io/controller-runtime/pkg/client"
+
+	ytv1 "github.com/ytsaurus/ytsaurus-k8s-operator/api/v1"
 )
 
 func getComponentPods(ctx context.Context, namespace string) map[string]corev1.Pod {
@@ -59,4 +62,18 @@ func getChangedPods(before, after map[string]corev1.Pod) changedObjects {
 		}
 	}
 	return ret
+}
+
+// updateSpecToTriggerAllComponentUpdate is a helper
+// that introduce spec change which should trigger change in all component static configs
+// and thus trigger all components update.
+func updateSpecToTriggerAllComponentUpdate(ytsaurus *ytv1.Ytsaurus) {
+	// ForceTCP is a field that is used in all components static configs
+	// so changing it should trigger all components update.
+	// Any value should be ok for test purposes.
+	if ytsaurus.Spec.ForceTCP == nil {
+		ytsaurus.Spec.ForceTCP = ptr.To(true)
+	} else {
+		ytsaurus.Spec.ForceTCP = nil
+	}
 }

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -317,8 +317,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 
 				By("Run cluster update with selector: nothing")
 				ytsaurus.Spec.UpdatePlan = []ytv1.ComponentUpdateSelector{{Class: consts.ComponentClassNothing}}
-				// We want change in all yson configs, new discovery instance will trigger that.
-				ytsaurus.Spec.CoreImage = testutil.CoreImageSecond
+				updateSpecToTriggerAllComponentUpdate(ytsaurus)
 				UpdateObject(ctx, ytsaurus)
 
 				By("Ensure cluster doesn't start updating for 5 seconds")
@@ -331,7 +330,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 
 				By("Update cluster update with strategy full")
 				ytsaurus.Spec.UpdatePlan = []ytv1.ComponentUpdateSelector{{Class: consts.ComponentClassEverything}}
-				ytsaurus.Spec.CoreImage = testutil.CoreImageNextVer
+				updateSpecToTriggerAllComponentUpdate(ytsaurus)
 				UpdateObject(ctx, ytsaurus)
 
 				EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveObservedGeneration())
@@ -363,7 +362,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						Type: consts.ExecNodeType,
 					},
 				}}
-				ytsaurus.Spec.CoreImage = testutil.CoreImageSecond
+				updateSpecToTriggerAllComponentUpdate(ytsaurus)
 				UpdateObject(ctx, ytsaurus)
 
 				EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveObservedGeneration())
@@ -385,7 +384,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						Type: consts.TabletNodeType,
 					},
 				}}
-				ytsaurus.Spec.CoreImage = testutil.CoreImageNextVer
+				updateSpecToTriggerAllComponentUpdate(ytsaurus)
 				UpdateObject(ctx, ytsaurus)
 
 				EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveObservedGeneration())
@@ -410,7 +409,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						Type: consts.MasterType,
 					},
 				}}
-				ytsaurus.Spec.CoreImage = testutil.CoreImageSecond
+				updateSpecToTriggerAllComponentUpdate(ytsaurus)
 				UpdateObject(ctx, ytsaurus)
 
 				EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveObservedGeneration())
@@ -429,7 +428,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				ytsaurus.Spec.UpdatePlan = []ytv1.ComponentUpdateSelector{{
 					Class: consts.ComponentClassStateless,
 				}}
-				ytsaurus.Spec.CoreImage = testutil.CoreImageNextVer
+				updateSpecToTriggerAllComponentUpdate(ytsaurus)
 				UpdateObject(ctx, ytsaurus)
 
 				EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveObservedGeneration())
@@ -470,11 +469,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						Name: "dn-2",
 					},
 				}}
-				// Updating images for all datanodes and discover, expecting only dn-2 to be updated.
-				for idx := range ytsaurus.Spec.DataNodes {
-					ytsaurus.Spec.DataNodes[idx].Image = ptr.To(testutil.CoreImageSecond)
-				}
-				ytsaurus.Spec.Discovery.Image = ptr.To(testutil.CoreImageSecond)
+				updateSpecToTriggerAllComponentUpdate(ytsaurus)
 				UpdateObject(ctx, ytsaurus)
 
 				EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveObservedGeneration())


### PR DESCRIPTION
Follow up to https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/455 
Here we use forceTCP option to trigger update of all components in updateSelector spec instead of image change.