### PR TITLE
Deleted the `stderr` logger for JobProxy.

### DIFF
--- a/config/samples/cluster_v1_cri.yaml
+++ b/config/samples/cluster_v1_cri.yaml
@@ -250,6 +250,10 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicyJobs
+        # this file is append-only and not rotated
+        # - name: error
+        #   minLogLevel: error
+        #   writerType: stderr
 
       resources:
         # Allocate resources for exec node container

--- a/config/samples/cluster_v1_cri.yaml
+++ b/config/samples/cluster_v1_cri.yaml
@@ -250,9 +250,6 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicyJobs
-        - name: error
-          minLogLevel: error
-          writerType: stderr
 
       resources:
         # Allocate resources for exec node container

--- a/config/samples/cluster_v1_demo.yaml
+++ b/config/samples/cluster_v1_demo.yaml
@@ -98,6 +98,10 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicy
+        # this file is append-only and not rotated
+        # - name: error
+        #   minLogLevel: error
+        #   writerType: stderr
 
   tabletNodes:
     - instanceCount: 3

--- a/config/samples/cluster_v1_demo.yaml
+++ b/config/samples/cluster_v1_demo.yaml
@@ -98,9 +98,6 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicy
-        - name: error
-          minLogLevel: error
-          writerType: stderr
 
   tabletNodes:
     - instanceCount: 3
@@ -122,7 +119,7 @@ spec:
   ui:
     serviceType: NodePort
     instanceCount: 1
- 
+
   strawberry:
     image: ghcr.io/ytsaurus/strawberry:0.0.11
     resources:

--- a/config/samples/cluster_v1_local.yaml
+++ b/config/samples/cluster_v1_local.yaml
@@ -129,6 +129,10 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicy
+        # this file is append-only and not rotated
+        # - name: error
+        #   minLogLevel: error
+        #   writerType: stderr
 
   schedulers:
     instanceCount: 1

--- a/config/samples/cluster_v1_local.yaml
+++ b/config/samples/cluster_v1_local.yaml
@@ -129,9 +129,6 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicy
-        - name: error
-          minLogLevel: error
-          writerType: stderr
 
   schedulers:
     instanceCount: 1

--- a/config/samples/cluster_v1_local_with_kafka.yaml
+++ b/config/samples/cluster_v1_local_with_kafka.yaml
@@ -136,9 +136,6 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicy
-        - name: error
-          minLogLevel: error
-          writerType: stderr
 
   schedulers:
     instanceCount: 1

--- a/config/samples/cluster_v1_local_with_kafka.yaml
+++ b/config/samples/cluster_v1_local_with_kafka.yaml
@@ -136,6 +136,10 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicy
+        # this file is append-only and not rotated
+        # - name: error
+        #   minLogLevel: error
+        #   writerType: stderr
 
   schedulers:
     instanceCount: 1

--- a/config/samples/cluster_v1_remoteexecnodes.yaml
+++ b/config/samples/cluster_v1_remoteexecnodes.yaml
@@ -58,9 +58,6 @@ spec:
       minLogLevel: info
       writerType: file
       rotationPolicy: *rotationPolicyJobs
-    - name: error
-      minLogLevel: error
-      writerType: stderr
 
   resources:
     # Allocate resources for exec node container

--- a/config/samples/cluster_v1_remoteexecnodes.yaml
+++ b/config/samples/cluster_v1_remoteexecnodes.yaml
@@ -58,6 +58,10 @@ spec:
       minLogLevel: info
       writerType: file
       rotationPolicy: *rotationPolicyJobs
+    # this file is append-only and not rotated
+    # - name: error
+    #   minLogLevel: error
+    #   writerType: stderr
 
   resources:
     # Allocate resources for exec node container

--- a/config/samples/cluster_v1_tls.yaml
+++ b/config/samples/cluster_v1_tls.yaml
@@ -270,6 +270,10 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicyJobs
+        # this file is append-only and not rotated
+        # - name: error
+        #   minLogLevel: error
+        #   writerType: stderr
 
       resources:
         # Allocate resources for exec node container

--- a/config/samples/cluster_v1_tls.yaml
+++ b/config/samples/cluster_v1_tls.yaml
@@ -270,9 +270,6 @@ spec:
           minLogLevel: info
           writerType: file
           rotationPolicy: *rotationPolicyJobs
-        - name: error
-          minLogLevel: error
-          writerType: stderr
 
       resources:
         # Allocate resources for exec node container


### PR DESCRIPTION
At the moment, this file is not rotated by the standard ytsaurus mechanisms and is rapidly growing due to the recording of irrelevant errors in it (errors specific only to the porto installation).