### PR TITLE
Revert "Disable stockpile by default"

### DIFF
--- a/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10014;
     "rpc_port"=9014;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-trash-ttl/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-trash-ttl/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10012;
     "rpc_port"=9012;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-watermark/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-watermark/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10012;
     "rpc_port"=9012;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/without-trash-ttl/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/without-trash-ttl/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10012;
     "rpc_port"=9012;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10012;
     "rpc_port"=9012;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "host1.external.address:9010";

--- a/pkg/ytconfig/canondata/TestGetDiscoveryConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDiscoveryConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10020;
     "rpc_port"=9020;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfig/with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfig/with-job-resources/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10029;
     "rpc_port"=9029;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfig/without-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfig/without-job-resources/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10029;
     "rpc_port"=9029;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-with-job-resources/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10029;
     "rpc_port"=9029;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-without-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-without-job-resources/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10029;
     "rpc_port"=9029;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-with-job-resources/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10029;
     "rpc_port"=9029;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-without-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-without-job-resources/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10029;
     "rpc_port"=9029;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10029;
     "rpc_port"=9029;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "host1.external.address:9010";

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10016;
     "rpc_port"=9016;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyConfigDisableCreateOauthUser/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyConfigDisableCreateOauthUser/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10016;
     "rpc_port"=9016;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyConfigEnableCreateOauthUser/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyConfigEnableCreateOauthUser/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10016;
     "rpc_port"=9016;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetMasterCachesConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterCachesConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10018;
     "rpc_port"=9018;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetMasterCachesWithFixedHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterCachesWithFixedHostsConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10018;
     "rpc_port"=9018;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetMasterConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterConfig/test.canondata
@@ -67,9 +67,6 @@
     };
     "monitoring_port"=10010;
     "rpc_port"=9010;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetMasterWithFixedHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterWithFixedHostsConfig/test.canondata
@@ -67,9 +67,6 @@
     };
     "monitoring_port"=10010;
     "rpc_port"=9010;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "host1.external.address:9010";

--- a/pkg/ytconfig/canondata/TestGetMasterWithMonitoringPortConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterWithMonitoringPortConfig/test.canondata
@@ -67,9 +67,6 @@
     };
     "monitoring_port"=20010;
     "rpc_port"=9010;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetQueryTrackerConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetQueryTrackerConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10028;
     "rpc_port"=9028;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetQueueAgentConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetQueueAgentConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10030;
     "rpc_port"=9030;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetRPCProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetRPCProxyConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10013;
     "rpc_port"=9013;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10013;
     "rpc_port"=9013;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetSchedulerConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetSchedulerConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10011;
     "rpc_port"=9011;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetSchedulerWithFixedMasterHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetSchedulerWithFixedMasterHostsConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10011;
     "rpc_port"=9011;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "host1.external.address:9010";

--- a/pkg/ytconfig/canondata/TestGetTCPProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTCPProxyConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10017;
     "rpc_port"=0;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetTabletNodeConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTabletNodeConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10022;
     "rpc_port"=9022;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetTabletNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTabletNodeWithoutYtsaurusConfig/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10022;
     "rpc_port"=9022;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "host1.external.address:9010";

--- a/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYQLAgentConfig/test.canondata
@@ -57,9 +57,6 @@
     };
     "monitoring_port"=10019;
     "rpc_port"=9019;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/discovery/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/discovery/test.canondata
@@ -53,9 +53,6 @@
             "file_name"="/tls/bus_secret/tls.key";
         };
     };
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/exec-node/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/exec-node/test.canondata
@@ -53,9 +53,6 @@
             "file_name"="/tls/bus_secret/tls.key";
         };
     };
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/master-cache/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/master-cache/test.canondata
@@ -44,9 +44,6 @@
     };
     "monitoring_port"=10018;
     "rpc_port"=9018;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/master/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/master/test.canondata
@@ -76,9 +76,6 @@
             "file_name"="/tls/bus_secret/tls.key";
         };
     };
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/queue-agent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/queue-agent/test.canondata
@@ -53,9 +53,6 @@
             "file_name"="/tls/bus_secret/tls.key";
         };
     };
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/canondata/TestResolverOptionsKeepSocketAndForceTCP/test.canondata
+++ b/pkg/ytconfig/canondata/TestResolverOptionsKeepSocketAndForceTCP/test.canondata
@@ -69,9 +69,6 @@
     };
     "monitoring_port"=10010;
     "rpc_port"=9010;
-    stockpile={
-        "thread_count"=0;
-    };
     "timestamp_provider"={
         addresses=[
             "ms-test-0.masters-test.fake.svc.fake.zone:9010";

--- a/pkg/ytconfig/common.go
+++ b/pkg/ytconfig/common.go
@@ -69,14 +69,6 @@ type SolomonExporter struct {
 	InstanceTags map[string]string `yson:"instance_tags,omitempty"`
 }
 
-type Stockpile struct {
-	BufferSize                  int           `yson:"buffer_size,omitempty"`
-	ThreadCount                 int           `yson:"thread_count"`
-	Strategy                    string        `yson:"strategy,omitempty"`
-	Period                      yson.Duration `yson:"period,omitempty"`
-	TotalMemoryFractionOverride float32       `yson:"total_memory_fraction_override,omitempty"`
-}
-
 type PemBlob struct {
 	FileName string `yson:"file_name,omitempty"`
 	Value    string `yson:"value,omitempty"`
@@ -121,7 +113,6 @@ type BasicServer struct {
 	MonitoringPort  int32           `yson:"monitoring_port"`
 	RPCPort         int32           `yson:"rpc_port"`
 	BusServer       *BusServer      `yson:"bus_server,omitempty"`
-	Stockpile       *Stockpile      `yson:"stockpile,omitempty"`
 }
 
 type CommonServer struct {

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -215,13 +215,6 @@ func (g *NodeGenerator) fillDriver(c *Driver) {
 	g.fillPrimaryMaster(&c.PrimaryMaster)
 }
 
-func (g *NodeGenerator) fillStockpile(c *BasicServer) {
-	// disable stockpile
-	c.Stockpile = &Stockpile{
-		ThreadCount: 0,
-	}
-}
-
 func (g *NodeGenerator) fillAddressResolver(c *AddressResolver) {
 	var retries = 1000
 	c.EnableIPv4 = g.commonSpec.UseIPv4
@@ -273,7 +266,6 @@ func (g *NodeGenerator) fillCypressAnnotations(c *CommonServer) {
 
 func (g *NodeGenerator) fillCommonService(c *CommonServer, s *ytv1.InstanceSpec) {
 	// ToDo(psushin): enable porto resource tracker?
-	g.fillStockpile(&c.BasicServer)
 	g.fillAddressResolver(&c.AddressResolver)
 	g.fillSolomonExporter(&c.SolomonExporter)
 	g.fillClusterConnection(&c.ClusterConnection, s.NativeTransport)


### PR DESCRIPTION
Reverts ytsaurus/ytsaurus-k8s-operator#467

The PR makes changes in all component's configs which leads to ytop wanting to update all components in all existing clusters on ytop update, which is not desired for mostly no-op config option. We will make this change optional.