### PR TITLE
Add E2E test for CHYT

### DIFF
--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -40,6 +40,14 @@ var (
 	QueryTrackerImagePrevious = GetenvOr("QUERY_TRACKER_IMAGE_PREVIOUS", "ghcr.io/ytsaurus/query-tracker:0.0.6")
 	QueryTrackerImageCurrent  = GetenvOr("QUERY_TRACKER_IMAGE_CURRENT", "ghcr.io/ytsaurus/query-tracker:0.0.9")
 	QueryTrackerImageFuture   = GetenvOr("QUERY_TRACKER_IMAGE_FUTURE", "ghcr.io/ytsaurus/query-tracker:0.0.9")
+
+	StrawberryImagePrevious = GetenvOr("STRAWBERRY_IMAGE_PREVIOUS", "ghcr.io/ytsaurus/strawberry:0.0.12")
+	StrawberryImageCurrent  = GetenvOr("STRAWBERRY_IMAGE_CURRENT", "ghcr.io/ytsaurus/strawberry:0.0.13")
+	StrawberryImageFuture   = GetenvOr("STRAWBERRY_IMAGE_FUTURE", "ghcr.io/ytsaurus/strawberry:0.0.13")
+
+	ChytImagePrevious = GetenvOr("CHYT_IMAGE_PREVIOUS", "ghcr.io/ytsaurus/chyt:2.14.0")
+	ChytImageCurrent  = GetenvOr("CHYT_IMAGE_CURRENT", "ghcr.io/ytsaurus/chyt:2.16.0")
+	ChytImageFuture   = GetenvOr("CHYT_IMAGE_FUTURE", "ghcr.io/ytsaurus/chyt:2.16.0")
 )
 
 var (
@@ -361,4 +369,28 @@ func (b *YtsaurusBuilder) CreateTabletNodeSpec(instanceCount int32) ytv1.Instanc
 		InstanceCount: instanceCount,
 		Loggers:       b.CreateLoggersSpec(),
 	}
+}
+
+func (b *YtsaurusBuilder) WithStrawberryController() {
+	b.Ytsaurus.Spec.StrawberryController = &ytv1.StrawberryControllerSpec{
+		Image: ptr.To(StrawberryImageCurrent),
+	}
+}
+
+func (b *YtsaurusBuilder) CreateChyt() *ytv1.Chyt {
+	chyt := ytv1.Chyt{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      YtsaurusName,
+			Namespace: b.Namespace,
+		},
+		Spec: ytv1.ChytSpec{
+			Ytsaurus: &corev1.LocalObjectReference{
+				Name: YtsaurusName,
+			},
+			Image:              ChytImageCurrent,
+			MakeDefault:        true,
+			CreatePublicClique: ptr.To(true),
+		},
+	}
+	return &chyt
 }

--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -43,9 +43,9 @@ var (
 )
 
 var (
-	masterVolumeSize, _   = resource.ParseQuantity("5Gi")
-	dataNodeVolumeSize, _ = resource.ParseQuantity("5Gi")
-	execNodeVolumeSize, _ = resource.ParseQuantity("5Gi")
+	masterVolumeSize   = resource.MustParse("5Gi")
+	dataNodeVolumeSize = resource.MustParse("5Gi")
+	execNodeVolumeSize = resource.MustParse("5Gi")
 )
 
 type YtsaurusBuilder struct {
@@ -307,19 +307,10 @@ func getPortFromEnv(envvar string) *int32 {
 }
 
 func (b *YtsaurusBuilder) CreateExecNodeSpec() ytv1.ExecNodesSpec {
-	execNodeCPU, _ := resource.ParseQuantity("1")
-	execNodeMemory, _ := resource.ParseQuantity("2Gi")
-
 	return ytv1.ExecNodesSpec{
 		InstanceSpec: ytv1.InstanceSpec{
 			InstanceCount: 1,
-			Resources: corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    execNodeCPU,
-					corev1.ResourceMemory: execNodeMemory,
-				},
-			},
-			Loggers: b.CreateLoggersSpec(),
+			Loggers:       b.CreateLoggersSpec(),
 			Locations: []ytv1.LocationSpec{
 				{
 					LocationType: "ChunkCache",

--- a/test-env.inc
+++ b/test-env.inc
@@ -1,5 +1,6 @@
 # vim: set filetype=make :
 
+# https://ytsaurus.tech/docs/en/admin-guide/releases
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus
 # https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus-nightly
 
@@ -20,6 +21,14 @@ export YTSAURUS_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-24.2-2
 export QUERY_TRACKER_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/query-tracker:0.0.6
 export QUERY_TRACKER_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/query-tracker:0.0.9
 export QUERY_TRACKER_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/query-tracker:0.0.9
+
+export STRAWBERRY_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/strawberry:0.0.12
+export STRAWBERRY_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/strawberry:0.0.13
+export STRAWBERRY_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/strawberry:0.0.13
+
+export CHYT_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/chyt:2.14.0
+export CHYT_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/chyt:2.16.0
+export CHYT_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/chyt:2.16.0
 
 define LOAD_TEST_IMAGES
 ${YTSAURUS_IMAGE_23_2}


### PR DESCRIPTION
- test/e2e: validate cluster by vanilla operation
  Add active check than cluster is able to run operations.
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
- Add strawberry and chyt into e2e
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
