### PR TITLE
Fix atomic status update in update plan logic

### DIFF
--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -179,7 +179,10 @@ func NewYtsaurusStatusTracker() func(*ytv1.Ytsaurus) bool {
 		}
 
 		if prevStatus.ObservedGeneration != newStatus.ObservedGeneration {
-			log.Info("ObservedGeneration", "current", newStatus.ObservedGeneration, "previous", prevStatus.ObservedGeneration)
+			log.Info("ObservedGeneration",
+				"current", newStatus.ObservedGeneration,
+				"previous", prevStatus.ObservedGeneration,
+				"observed", newStatus.ObservedGeneration == ytsaurus.Generation)
 			changed = true
 		}
 
@@ -201,8 +204,23 @@ func NewYtsaurusStatusTracker() func(*ytv1.Ytsaurus) bool {
 			changed = true
 		}
 
+		if prevStatus.UpdateStatus.Flow != newStatus.UpdateStatus.Flow {
+			log.Info("UpdateStatus", "flow", newStatus.UpdateStatus.Flow)
+			changed = true
+		}
+
 		if len(prevStatus.UpdateStatus.UpdatingComponents) != len(newStatus.UpdateStatus.UpdatingComponents) {
 			log.Info("UpdateStatus", "updatingComponents", newStatus.UpdateStatus.UpdatingComponents)
+			changed = true
+		}
+
+		if len(prevStatus.UpdateStatus.UpdatingComponentsSummary) != len(newStatus.UpdateStatus.UpdatingComponentsSummary) {
+			log.Info("UpdateStatus", "updatingComponentsSummary", newStatus.UpdateStatus.UpdatingComponentsSummary)
+			changed = true
+		}
+
+		if len(prevStatus.UpdateStatus.BlockedComponentsSummary) != len(newStatus.UpdateStatus.BlockedComponentsSummary) {
+			log.Info("UpdateStatus", "blockedComponentsSummary", newStatus.UpdateStatus.BlockedComponentsSummary)
 			changed = true
 		}
 


### PR DESCRIPTION
- test/e2e: track update status fields
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
- Fix race in update selector logic
  Untangle code. Too many nested ifs for no good reason.
  
  Commit status update in one transaction and
  always update observed generation.
  
  Do not retry processing if nothing have changed.
  
  Check in testcases blocked updates.
  Check that they are unblocked after updating plan.
  
  Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
  
