### PR TITLE
test: skip case broken for macos

### DIFF
--- a/controllers/remotedatanodes_test.go
+++ b/controllers/remotedatanodes_test.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package controllers_test
 
 import (

--- a/controllers/remoteexecnodes_test.go
+++ b/controllers/remoteexecnodes_test.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package controllers_test
 
 import (

--- a/controllers/remotetabletnodes_test.go
+++ b/controllers/remotetabletnodes_test.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package controllers_test
 
 import (

--- a/controllers/ytsaurus_local_test.go
+++ b/controllers/ytsaurus_local_test.go
@@ -1,3 +1,5 @@
+//go:build !darwin
+
 package controllers_test
 
 import (


### PR DESCRIPTION
No reason to fix that before switching to ginkgo.
They are likely racy and works on linux just by luck.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
