### PR TITLE
Keep in cluster connection both environment and file certificate sources

### DIFF
--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/ClusterConnection/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/ClusterConnection/test.canondata
@@ -23,12 +23,15 @@
         "encryption_mode"=required;
         "cert_chain"={
             "environment_variable"="YT_SECURE_VAULT_YT_BUS_CLIENT_CERTIFICATE";
+            "file_name"="/tls/bus_client_secret/tls.crt";
         };
         "private_key"={
             "environment_variable"="YT_SECURE_VAULT_YT_BUS_CLIENT_PRIVATE_KEY";
+            "file_name"="/tls/bus_client_secret/tls.key";
         };
         ca={
             "environment_variable"="YT_SECURE_VAULT_YT_BUS_CA_BUNDLE";
+            "file_name"="/tls/ca_bundle/ca.crt";
         };
         "verification_mode"=full;
         "peer_alternative_host_name"="fake.svc.cluster.local";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/ExecNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/ExecNode/test.canondata
@@ -276,12 +276,15 @@
                     "encryption_mode"=required;
                     "cert_chain"={
                         "environment_variable"="YT_SECURE_VAULT_YT_BUS_CLIENT_CERTIFICATE";
+                        "file_name"="/tls/bus_client_secret/tls.crt";
                     };
                     "private_key"={
                         "environment_variable"="YT_SECURE_VAULT_YT_BUS_CLIENT_PRIVATE_KEY";
+                        "file_name"="/tls/bus_client_secret/tls.key";
                     };
                     ca={
                         "environment_variable"="YT_SECURE_VAULT_YT_BUS_CA_BUNDLE";
+                        "file_name"="/tls/ca_bundle/ca.crt";
                     };
                     "verification_mode"=full;
                     "peer_alternative_host_name"="fake.svc.cluster.local";
@@ -300,12 +303,15 @@
                 "encryption_mode"=required;
                 "cert_chain"={
                     "environment_variable"="YT_SECURE_VAULT_YT_BUS_CLIENT_CERTIFICATE";
+                    "file_name"="/tls/bus_client_secret/tls.crt";
                 };
                 "private_key"={
                     "environment_variable"="YT_SECURE_VAULT_YT_BUS_CLIENT_PRIVATE_KEY";
+                    "file_name"="/tls/bus_client_secret/tls.key";
                 };
                 ca={
                     "environment_variable"="YT_SECURE_VAULT_YT_BUS_CA_BUNDLE";
+                    "file_name"="/tls/ca_bundle/ca.crt";
                 };
                 "verification_mode"=full;
                 "peer_alternative_host_name"="fake.svc.cluster.local";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/StrawberryController/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/StrawberryController/test.canondata
@@ -18,12 +18,15 @@
                 "encryption_mode"=required;
                 "cert_chain"={
                     "environment_variable"="YT_SECURE_VAULT_YT_BUS_SERVER_CERTIFICATE";
+                    "file_name"="/tls/bus_secret/tls.crt";
                 };
                 "private_key"={
                     "environment_variable"="YT_SECURE_VAULT_YT_BUS_SERVER_PRIVATE_KEY";
+                    "file_name"="/tls/bus_secret/tls.key";
                 };
                 ca={
                     "environment_variable"="YT_SECURE_VAULT_YT_BUS_CA_BUNDLE";
+                    "file_name"="/tls/ca_bundle/ca.crt";
                 };
                 "verification_mode"=full;
                 "peer_alternative_host_name"="fake.svc.cluster.local";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/StrawberryController/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/StrawberryController/test.canondata
@@ -18,9 +18,11 @@
                 "encryption_mode"=optional;
                 "cert_chain"={
                     "environment_variable"="YT_SECURE_VAULT_YT_BUS_SERVER_CERTIFICATE";
+                    "file_name"="/tls/bus_secret/tls.crt";
                 };
                 "private_key"={
                     "environment_variable"="YT_SECURE_VAULT_YT_BUS_SERVER_PRIVATE_KEY";
+                    "file_name"="/tls/bus_secret/tls.key";
                 };
                 "verification_mode"=none;
             };

--- a/pkg/ytconfig/keyring.go
+++ b/pkg/ytconfig/keyring.go
@@ -60,7 +60,7 @@ func getMountKeyring(commonSpec *ytv1.CommonSpec, transportSpec *ytv1.RPCTranspo
 	return &keyring
 }
 
-// Certificates from secure vault environment variables
+// Certificates from secure vault environment variables with file fallback
 func getVaultKeyring(commonSpec *ytv1.CommonSpec, transportSpec *ytv1.RPCTransportSpec) *Keyring {
 	if transportSpec == nil {
 		transportSpec = commonSpec.NativeTransport
@@ -74,6 +74,7 @@ func getVaultKeyring(commonSpec *ytv1.CommonSpec, transportSpec *ytv1.RPCTranspo
 	if commonSpec.CABundle != nil {
 		keyring.BusCABundle = &PemBlob{
 			EnvironmentVariable: consts.SecureVaultEnvPrefix + consts.BusCABundleVaultName,
+			FileName:            path.Join(consts.CABundleMountPoint, consts.CABundleFileName),
 		}
 	} else {
 		keyring.BusCABundle = &PemBlob{
@@ -84,18 +85,22 @@ func getVaultKeyring(commonSpec *ytv1.CommonSpec, transportSpec *ytv1.RPCTranspo
 	if transportSpec.TLSSecret != nil {
 		keyring.BusServerCertificate = &PemBlob{
 			EnvironmentVariable: consts.SecureVaultEnvPrefix + consts.BusServerCertificateVaultName,
+			FileName:            path.Join(consts.BusServerSecretMountPoint, corev1.TLSCertKey),
 		}
 		keyring.BusServerPrivateKey = &PemBlob{
 			EnvironmentVariable: consts.SecureVaultEnvPrefix + consts.BusServerPrivateKeyVaultName,
+			FileName:            path.Join(consts.BusServerSecretMountPoint, corev1.TLSPrivateKeyKey),
 		}
 	}
 
 	if transportSpec.TLSClientSecret != nil {
 		keyring.BusClientCertificate = &PemBlob{
 			EnvironmentVariable: consts.SecureVaultEnvPrefix + consts.BusClientCertificateVaultName,
+			FileName:            path.Join(consts.BusClientSecretMountPoint, corev1.TLSCertKey),
 		}
 		keyring.BusClientPrivateKey = &PemBlob{
 			EnvironmentVariable: consts.SecureVaultEnvPrefix + consts.BusClientPrivateKeyVaultName,
+			FileName:            path.Join(consts.BusClientSecretMountPoint, corev1.TLSPrivateKeyKey),
 		}
 	}
 


### PR DESCRIPTION
This allows to share cluster connection config between server and jobs.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
