### PR TITLE
test/e2e: update ytsaurus test images - switch to 24.2

### DIFF
--- a/.github/workflows/subflow_run_e2e_tests.yaml
+++ b/.github/workflows/subflow_run_e2e_tests.yaml
@@ -78,11 +78,6 @@ jobs:
           make helm-kind-install
           kubectl get pod -A
 
-      - name: Pull YTsaurus images
-        shell: bash
-        run: |
-          make kind-load-test-images
-
       - name: Run ${{ matrix.e2e.name }} e2e tests
         env:
           GINKGO_LABEL_FILTER: ${{ matrix.e2e.filter }}

--- a/Makefile
+++ b/Makefile
@@ -149,8 +149,7 @@ test: generate-code manifests envtest-assets ## Run tests.
 
 .PHONY: test-e2e
 test-e2e: generate-code manifests ginkgo ## Run e2e tests.
-	YTSAURUS_ENABLE_E2E_TESTS=true \
-	$(GINKGO) $(GINKGO_FLAGS) ./test/e2e/... -coverprofile cover.out -timeout 1800s
+	$(GINKGO) $(GINKGO_FLAGS) ./test/e2e/... -coverprofile cover.out -timeout 1800s -- --enable-e2e
 
 .PHONY: clean-e2e
 clean-e2e: ## Delete k8s namespaces created by e2e tests.

--- a/Makefile
+++ b/Makefile
@@ -152,6 +152,10 @@ test-e2e: generate-code manifests ginkgo ## Run e2e tests.
 	YTSAURUS_ENABLE_E2E_TESTS=true \
 	$(GINKGO) $(GINKGO_FLAGS) ./test/e2e/... -coverprofile cover.out -timeout 1800s
 
+.PHONY: clean-e2e
+clean-e2e: ## Delete k8s namespaces created by e2e tests.
+	$(KUBECTL) delete namespaces -l app.kubernetes.io/part-of=ytsaurus-dev
+
 .PHONY: lint
 lint: golangci-lint ## Run golangci-lint linter.
 	$(GOLANGCI_LINT) run

--- a/pkg/components/init_job.go
+++ b/pkg/components/init_job.go
@@ -139,6 +139,7 @@ func (j *InitJob) Build() *batchv1.Job {
 					VolumeMounts: []corev1.VolumeMount{
 						createConfigVolumeMount(),
 					},
+					TerminationMessagePolicy: corev1.TerminationMessageFallbackToLogsOnError,
 				},
 			},
 			Volumes: []corev1.Volume{

--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -26,28 +26,32 @@ const (
 )
 
 // Images are should be set by TEST_ENV include in Makefile
-// FIXME(khlebnikov): Maybe embed test env file for defaults
 var (
 	YtsaurusImage23_2 = GetenvOr("YTSAURUS_IMAGE_23_2", "ghcr.io/ytsaurus/ytsaurus:stable-23.2.0")
 	YtsaurusImage24_1 = GetenvOr("YTSAURUS_IMAGE_24_1", "ghcr.io/ytsaurus/ytsaurus:stable-24.1.0")
-	YtsaurusImage24_2 = GetenvOr("YTSAURUS_IMAGE_24_2", "ghcr.io/ytsaurus/ytsaurus:stable-24.2.0")
+	YtsaurusImage24_2 = GetenvOr("YTSAURUS_IMAGE_24_2", "ghcr.io/ytsaurus/ytsaurus:stable-24.2.1")
+	YtsaurusImage25_1 = GetenvOr("YTSAURUS_IMAGE_25_1", "")
+	YtsaurusImage25_2 = GetenvOr("YTSAURUS_IMAGE_25_2", "")
 
-	YtsaurusImagePrevious = GetenvOr("YTSAURUS_IMAGE_PREVIOUS", YtsaurusImage23_2)
-	YtsaurusImageCurrent  = GetenvOr("YTSAURUS_IMAGE_CURRENT", YtsaurusImage24_1)
-	YtsaurusImageFuture   = GetenvOr("YTSAURUS_IMAGE_FUTURE", YtsaurusImage24_2)
-	YtsaurusImageNightly  = GetenvOr("YTSAURUS_IMAGE_NIGHTLY", "ghcr.io/ytsaurus/ytsaurus-nightly:dev-24.2-2025-03-19-2973ab7cb36ed53ae3cbe9c37b8c7f55eb9c4e77")
+	YtsaurusImagePrevious = GetenvOr("YTSAURUS_IMAGE_PREVIOUS", YtsaurusImage24_1)
+	YtsaurusImageCurrent  = GetenvOr("YTSAURUS_IMAGE_CURRENT", YtsaurusImage24_2)
+	YtsaurusImageFuture   = GetenvOr("YTSAURUS_IMAGE_FUTURE", YtsaurusImage25_1)
+	YtsaurusImageNightly  = GetenvOr("YTSAURUS_IMAGE_NIGHTLY", "")
 
-	QueryTrackerImagePrevious = GetenvOr("QUERY_TRACKER_IMAGE_PREVIOUS", "ghcr.io/ytsaurus/query-tracker:0.0.6")
-	QueryTrackerImageCurrent  = GetenvOr("QUERY_TRACKER_IMAGE_CURRENT", "ghcr.io/ytsaurus/query-tracker:0.0.9")
-	QueryTrackerImageFuture   = GetenvOr("QUERY_TRACKER_IMAGE_FUTURE", "ghcr.io/ytsaurus/query-tracker:0.0.9")
+	QueryTrackerImagePrevious = GetenvOr("QUERY_TRACKER_IMAGE_PREVIOUS", "ghcr.io/ytsaurus/query-tracker:0.0.9")
+	QueryTrackerImageCurrent  = GetenvOr("QUERY_TRACKER_IMAGE_CURRENT", "ghcr.io/ytsaurus/query-tracker:0.0.10")
+	QueryTrackerImageFuture   = GetenvOr("QUERY_TRACKER_IMAGE_FUTURE", "")
+	QueryTrackerImageNightly  = GetenvOr("QUERY_TRACKER_IMAGE_NIGHTLY", "")
 
 	StrawberryImagePrevious = GetenvOr("STRAWBERRY_IMAGE_PREVIOUS", "ghcr.io/ytsaurus/strawberry:0.0.12")
 	StrawberryImageCurrent  = GetenvOr("STRAWBERRY_IMAGE_CURRENT", "ghcr.io/ytsaurus/strawberry:0.0.13")
-	StrawberryImageFuture   = GetenvOr("STRAWBERRY_IMAGE_FUTURE", "ghcr.io/ytsaurus/strawberry:0.0.13")
+	StrawberryImageFuture   = GetenvOr("STRAWBERRY_IMAGE_FUTURE", "")
+	StrawberryImageNightly  = GetenvOr("STRAWBERRY_IMAGE_NIGHTLY", "")
 
-	ChytImagePrevious = GetenvOr("CHYT_IMAGE_PREVIOUS", "ghcr.io/ytsaurus/chyt:2.14.0")
-	ChytImageCurrent  = GetenvOr("CHYT_IMAGE_CURRENT", "ghcr.io/ytsaurus/chyt:2.16.0")
-	ChytImageFuture   = GetenvOr("CHYT_IMAGE_FUTURE", "ghcr.io/ytsaurus/chyt:2.16.0")
+	ChytImagePrevious = GetenvOr("CHYT_IMAGE_PREVIOUS", "ghcr.io/ytsaurus/chyt:2.16.0")
+	ChytImageCurrent  = GetenvOr("CHYT_IMAGE_CURRENT", "ghcr.io/ytsaurus/chyt:2.17.2")
+	ChytImageFuture   = GetenvOr("CHYT_IMAGE_FUTURE", "")
+	ChytImageNightly  = GetenvOr("CHYT_IMAGE_NIGHTLY", "")
 )
 
 var (

--- a/test-env.inc
+++ b/test-env.inc
@@ -1,40 +1,66 @@
 # vim: set filetype=make :
 
 # https://ytsaurus.tech/docs/en/admin-guide/releases
-# https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus
-# https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus-nightly
 
 YTSAURUS_REGISTRY = ghcr.io/ytsaurus
 
 # options for e2e tests
 
+# https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus
+# https://github.com/ytsaurus/ytsaurus/pkgs/container/ytsaurus-nightly
+# skopeo inspect --format '{{range .RepoTags}}{{.}}\n{{end -}}' docker://ghcr.io/ytsaurus/ytsaurus-nightly
+
 export YTSAURUS_IMAGE_23_2 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-23.2.0
+# export YTSAURUS_IMAGE_23_2 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-23.2-2025-02-19-7dae008dd5171a9c89857f2034746ac3119842db
+
 export YTSAURUS_IMAGE_24_1 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-24.1.0
-export YTSAURUS_IMAGE_24_2 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-24.2.0
+# export YTSAURUS_IMAGE_24_1 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-24.1-2025-06-18-dd4bd8bdc4d28993e7185b820930761540b29ae9
 
-export YTSAURUS_IMAGE_PREVIOUS = ${YTSAURUS_IMAGE_23_2}
-export YTSAURUS_IMAGE_CURRENT = ${YTSAURUS_IMAGE_24_1}
-export YTSAURUS_IMAGE_FUTURE = ${YTSAURUS_IMAGE_24_2}
+export YTSAURUS_IMAGE_24_2 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-24.2.1
+# export YTSAURUS_IMAGE_24_2 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-24.2-2025-07-28-567fa5b92fd448f708f84f7755dacf4560810ef6
 
-export YTSAURUS_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-24.2-2025-03-19-2973ab7cb36ed53ae3cbe9c37b8c7f55eb9c4e77
+# export YTSAURUS_IMAGE_25_1 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-25.1.0 # missing
+export YTSAURUS_IMAGE_25_1 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-25.1-2025-07-28-b75342ada631c8d78b95c29c4de46225c877f1d2
 
-export QUERY_TRACKER_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/query-tracker:0.0.6
-export QUERY_TRACKER_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/query-tracker:0.0.9
-export QUERY_TRACKER_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/query-tracker:0.0.9
+# export YTSAURUS_IMAGE_25_2 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-25.2.0 # missing
+# export YTSAURUS_IMAGE_25_2 = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-25.2-2025-07-04-6f04dd8da0ad0b87ed992ac6f80b58b9ce04fbd3
 
+export YTSAURUS_IMAGE_PREVIOUS = ${YTSAURUS_IMAGE_24_1}
+export YTSAURUS_IMAGE_CURRENT = ${YTSAURUS_IMAGE_24_2}
+export YTSAURUS_IMAGE_FUTURE = ${YTSAURUS_IMAGE_25_1}
+# export YTSAURUS_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/ytsaurus-nightly:dev-2025-07-21-bc55d64bab08263dbc85557f4f537d2504bb6080
+
+# https://github.com/ytsaurus/ytsaurus/pkgs/container/query-tracker
+# https://github.com/ytsaurus/ytsaurus/pkgs/container/query-tracker-nightly
+# skopeo inspect --format '{{range .RepoTags}}{{.}}\n{{end -}}' docker://ghcr.io/ytsaurus/query-tracker-nightly:dev-2025-07-23-be855609d82ae5c6952a6b5c8c4e1706d1b18232
+export QUERY_TRACKER_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/query-tracker:0.0.9
+export QUERY_TRACKER_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/query-tracker:0.0.10
+# export QUERY_TRACKER_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/query-tracker:0.0.9
+# export QUERY_TRACKER_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/query-tracker-nightly:dev-2025-07-23-54e157536780b978957c79559a88d605a42e0ca0
+
+# https://github.com/ytsaurus/ytsaurus/pkgs/container/strawberry
+# https://github.com/ytsaurus/ytsaurus/pkgs/container/strawberry-nightly
+# skopeo inspect --format '{{range .RepoTags}}{{.}}\n{{end -}}' docker://ghcr.io/ytsaurus/strawberry-nightly:dev-2025-07-23-8c5b9c9b908af8b2f883de051b62072e795d40d3
 export STRAWBERRY_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/strawberry:0.0.12
 export STRAWBERRY_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/strawberry:0.0.13
-export STRAWBERRY_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/strawberry:0.0.13
+# export STRAWBERRY_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/strawberry:0.0.13
+# export STRAWBERRY_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/strawberry-nightly:dev-2025-07-23-0a27143f2b3962d3e25ef7b5822b9969d64aa2dc
 
-export CHYT_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/chyt:2.14.0
-export CHYT_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/chyt:2.16.0
-export CHYT_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/chyt:2.16.0
+# https://github.com/ytsaurus/ytsaurus/pkgs/container/chyt
+# https://github.com/ytsaurus/ytsaurus/pkgs/container/chyt-nightly
+# skopeo inspect --format '{{range .RepoTags}}{{.}}\n{{end -}}' docker://ghcr.io/ytsaurus/chyt-nightly:dev-2025-07-23-85732937466aec6368c1582345afdedff70c5007
+export CHYT_IMAGE_PREVIOUS = ${YTSAURUS_REGISTRY}/chyt:2.16.0
+export CHYT_IMAGE_CURRENT = ${YTSAURUS_REGISTRY}/chyt:2.17.2
+# export CHYT_IMAGE_FUTURE = ${YTSAURUS_REGISTRY}/chyt:2.17.2
+# export CHYT_IMAGE_NIGHTLY = ${YTSAURUS_REGISTRY}/chyt-nightly:dev-2025-07-23-85732937466aec6368c1582345afdedff70c5007
 
 define LOAD_TEST_IMAGES
 ${YTSAURUS_IMAGE_23_2}
-${YTSAURUS_IMAGE_24_1}
-${YTSAURUS_IMAGE_24_2}
-${YTSAURUS_IMAGE_NIGHTLY}
+${YTSAURUS_IMAGE_PREVIOUS}
+${YTSAURUS_IMAGE_CURRENT}
+${YTSAURUS_IMAGE_FUTURE}
+${QUERY_TRACKER_IMAGE_CURRENT}
+${CHYT_IMAGE_CURRENT}
 endef
 
 YTSAURUS_SAMPLE_IMAGE_24_1 = ${YTSAURUS_REGISTRY}/ytsaurus:stable-24.1.0-relwithdebinfo

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 
+	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	clientgoretry "k8s.io/client-go/util/retry"
 
@@ -60,6 +61,7 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var k8sClient client.WithWatch
+var clientset *kubernetes.Clientset
 var ctx context.Context
 var log = logf.Log
 
@@ -127,6 +129,10 @@ var _ = SynchronizedBeforeSuite(func(ctx context.Context) []byte {
 	k8sClient, err = client.NewWithWatch(cfg, client.Options{Scheme: scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
+
+	clientset, err = kubernetes.NewForConfig(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	Expect(clientset).NotTo(BeNil())
 })
 
 func ShouldPreserveArtifacts() bool {

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -264,6 +264,9 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 	})
 
 	JustBeforeEach(func(ctx context.Context) {
+		// NOTE: Testcase should skip optional cases at "BeforeEach" stage.
+		Expect(ytsaurus.Spec.CoreImage).ToNot(BeEmpty(), "ytsaurus core image is not specified")
+
 		By("Creating resource objects")
 		for _, object := range objects {
 			By(fmt.Sprintf("Creating %v %v", GetObjectGVK(object), object.GetName()))
@@ -545,6 +548,10 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 		DescribeTableSubtree("Updating Ytsaurus image",
 			func(oldImage, newImage string) {
 				BeforeEach(func() {
+					if oldImage == "" || newImage == "" {
+						Skip("Ytsaurus old or new image is not specified")
+					}
+
 					ytBuilder.WithNamedDataNodes(ptr.To("dn-t"))
 
 					By("Setting old core image for testing upgrade")
@@ -585,6 +592,8 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 			},
 			Entry("When update Ytsaurus 23.2 -> 24.1", Label("basic"), testutil.YtsaurusImage23_2, testutil.YtsaurusImage24_1),
 			Entry("When update Ytsaurus 24.1 -> 24.2", Label("basic"), testutil.YtsaurusImage24_1, testutil.YtsaurusImage24_2),
+			Entry("When update Ytsaurus 24.2 -> 25.1", Label("basic"), testutil.YtsaurusImage24_2, testutil.YtsaurusImage25_1),
+			Entry("When update Ytsaurus 25.1 -> 25.2", Label("basic"), testutil.YtsaurusImage25_1, testutil.YtsaurusImage25_2),
 		)
 
 		Context("Test UpdateSelector", Label("selector"), func() {
@@ -1462,8 +1471,10 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 		DescribeTableSubtree("With Bus RPC mTLS", Label("tls"), func(coreImage, chytImage string) {
 
 			BeforeEach(func() {
-
 				log.Info("YTsaurus images", "coreImage", coreImage, "chytImage", chytImage)
+				if coreImage == "" || chytImage == "" {
+					Skip("Ytsaurus or chyt image is not specified")
+				}
 
 				if os.Getenv("YTSAURUS_TLS_READY") == "" {
 					Skip("YTsaurus is not ready for TLS")
@@ -1541,6 +1552,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 		},
 			Entry("YTsaurus current", Label("current"), testutil.YtsaurusImageCurrent, testutil.ChytImageCurrent),
 			Entry("YTsaurus future", Label("future"), testutil.YtsaurusImageFuture, testutil.ChytImageFuture),
+			Entry("YTsaurus nightly", Label("nightly"), testutil.YtsaurusImageNightly, testutil.ChytImageNightly),
 		) // integration tls
 
 	}) // integration

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -1523,8 +1523,10 @@ func checkClusterHealth(ytClient yt.Client) {
 	Expect(ytClient.ListNode(ctx, ypath.Path("/"), &res, nil)).Should(Succeed())
 
 	By("Checking cluster alerts", func() {
-		clusterHealth := CollectClusterHealth(ytClient)
+		var clusterHealth ClusterHealthReport
+		clusterHealth.Collect(ytClient)
 		Expect(clusterHealth.Alerts).To(BeEmpty())
+		Expect(clusterHealth.Errors).To(BeEmpty())
 	})
 
 	By("Checking that tablet cell bundles are in `good` health")

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -295,6 +295,14 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 			return clusterHealth.String()
 		}))
 
+		DeferCleanup(AttachProgressReporter(func() string {
+			failedPods := fetchFailedPods(namespace)
+			if len(failedPods) != 0 {
+				return fmt.Sprintf("Failed pods: %v", failedPods)
+			}
+			return ""
+		}))
+
 		log.Info("Ytsaurus",
 			"namespace", ytsaurus.Namespace,
 			"name", ytsaurus.Name,


### PR DESCRIPTION
- Makefile add target clean-e2e
- test/e2e: rework safety options
- test/e2e: collect tablet health as warnings
- test/e2e: poll cluster health in progress report
- test/e2e: poll logs for failed pods
- test/e2e: update ytsaurus test images
- test/e2e: pull required images before test
- test/e2e: fix testing enable_real_chunk_locations for 25.1
