### PR TITLE
test/e2e: add job image

### DIFF
--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -27,6 +27,9 @@ const (
 
 // Images are should be set by TEST_ENV include in Makefile
 var (
+	//NOTE: The same image is used for ytsaurus integration tests.
+	YtsaurusJobImage = GetenvOr("YTSAURUS_JOB_IMAGE", "docker.io/library/python:3.8-slim")
+
 	YtsaurusImage23_2 = GetenvOr("YTSAURUS_IMAGE_23_2", "ghcr.io/ytsaurus/ytsaurus:stable-23.2.0")
 	YtsaurusImage24_1 = GetenvOr("YTSAURUS_IMAGE_24_1", "ghcr.io/ytsaurus/ytsaurus:stable-24.1.0")
 	YtsaurusImage24_2 = GetenvOr("YTSAURUS_IMAGE_24_2", "ghcr.io/ytsaurus/ytsaurus:stable-24.2.1")
@@ -63,6 +66,7 @@ var (
 type YtsaurusBuilder struct {
 	Namespace         string
 	YtsaurusImage     string
+	JobImage          *string
 	QueryTrackerImage string
 	Ytsaurus          *ytv1.Ytsaurus
 }
@@ -106,6 +110,7 @@ func (b *YtsaurusBuilder) CreateMinimal() {
 				EphemeralCluster: true,
 				UseShortNames:    true,
 				CoreImage:        b.YtsaurusImage,
+				JobImage:         b.JobImage,
 			},
 			EnableFullUpdate: true,
 			IsManaged:        true,
@@ -164,6 +169,7 @@ func CreateBaseYtsaurusResource(namespace string) *ytv1.Ytsaurus {
 	builder := YtsaurusBuilder{
 		Namespace:         namespace,
 		YtsaurusImage:     YtsaurusImageCurrent,
+		JobImage:          ptr.To(YtsaurusJobImage),
 		QueryTrackerImage: QueryTrackerImageCurrent,
 	}
 	builder.CreateMinimal()

--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -27,7 +27,7 @@ const (
 
 // Images are should be set by TEST_ENV include in Makefile
 var (
-	//NOTE: The same image is used for ytsaurus integration tests.
+	// NOTE: The same image is used for YTsaurus integration tests.
 	YtsaurusJobImage = GetenvOr("YTSAURUS_JOB_IMAGE", "docker.io/library/python:3.8-slim")
 
 	YtsaurusImage23_2 = GetenvOr("YTSAURUS_IMAGE_23_2", "ghcr.io/ytsaurus/ytsaurus:stable-23.2.0")

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -245,6 +245,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 		ytBuilder = &testutil.YtsaurusBuilder{
 			Namespace:         namespace,
 			YtsaurusImage:     testutil.YtsaurusImageCurrent,
+			JobImage:          ptr.To(testutil.YtsaurusJobImage),
 			QueryTrackerImage: testutil.QueryTrackerImageCurrent,
 		}
 		ytBuilder.CreateMinimal()
@@ -1195,6 +1196,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 						},
 						CommonSpec: ytv1.CommonSpec{
 							CoreImage: testutil.YtsaurusImageCurrent,
+							JobImage:  ptr.To(testutil.YtsaurusJobImage),
 						},
 						ExecNodesSpec: ytBuilder.CreateExecNodeSpec(),
 					},


### PR DESCRIPTION
There is no reason to pull whole ytsaurus image once again.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
