### PR TITLE
Allow native transport TLS without mTLS

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -369,10 +369,10 @@ type RPCTransportSpec struct {
 	// Client certificate. Reference to kubernetes.io/tls secret.
 	//+optional
 	TLSClientSecret *corev1.LocalObjectReference `json:"tlsClientSecret,omitempty"`
-	// Require encrypted connections, otherwise only when required by peer.
+	// Require secure TLS connections by server, otherwise only by client.
 	//+optional
 	TLSRequired bool `json:"tlsRequired,omitempty"`
-	// Disable TLS certificate verification.
+	// Disable client certificate verification when TLS is required, if not required - verify neither.
 	//+optional
 	TLSInsecure bool `json:"tlsInsecure,omitempty"`
 	// Define alternative host name for certificate verification.

--- a/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -980,14 +980,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -1170,14 +1170,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls

--- a/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -980,14 +980,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteytsaurus.yaml
@@ -921,14 +921,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -1009,15 +1009,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -3584,15 +3585,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -6167,15 +6169,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -8756,15 +8759,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -11569,15 +11573,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -14197,15 +14202,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -16828,15 +16834,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -19426,15 +19433,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -21133,14 +21141,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls
@@ -22094,15 +22103,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -24679,15 +24689,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -27250,15 +27261,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -29829,15 +29841,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -30047,15 +30060,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -32454,15 +32468,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -35050,15 +35065,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -37787,15 +37803,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -40387,15 +40404,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -43314,15 +43332,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls

--- a/docs/api.md
+++ b/docs/api.md
@@ -1459,8 +1459,8 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `tlsSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Server certificate. Reference to kubernetes.io/tls secret. |  |  |
 | `tlsClientSecret` _[LocalObjectReference](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#localobjectreference-v1-core)_ | Client certificate. Reference to kubernetes.io/tls secret. |  |  |
-| `tlsRequired` _boolean_ | Require encrypted connections, otherwise only when required by peer. |  |  |
-| `tlsInsecure` _boolean_ | Disable TLS certificate verification. |  |  |
+| `tlsRequired` _boolean_ | Require secure TLS connections by server, otherwise only by client. |  |  |
+| `tlsInsecure` _boolean_ | Disable client certificate verification when TLS is required, if not required - verify neither. |  |  |
 | `tlsPeerAlternativeHostName` _string_ | Define alternative host name for certificate verification. |  |  |
 
 

--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -41,6 +41,8 @@ var (
 	YtsaurusImageFuture   = GetenvOr("YTSAURUS_IMAGE_FUTURE", YtsaurusImage25_1)
 	YtsaurusImageNightly  = GetenvOr("YTSAURUS_IMAGE_NIGHTLY", "")
 
+	YtsaurusTLSReady = os.Getenv("YTSAURUS_TLS_READY") != ""
+
 	QueryTrackerImagePrevious = GetenvOr("QUERY_TRACKER_IMAGE_PREVIOUS", "ghcr.io/ytsaurus/query-tracker:0.0.9")
 	QueryTrackerImageCurrent  = GetenvOr("QUERY_TRACKER_IMAGE_CURRENT", "ghcr.io/ytsaurus/query-tracker:0.0.10")
 	QueryTrackerImageFuture   = GetenvOr("QUERY_TRACKER_IMAGE_FUTURE", "")

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ClusterConnection/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ClusterConnection/test.canondata
@@ -21,7 +21,12 @@
     };
     "bus_client"={
         "encryption_mode"=required;
-        "verification_mode"=none;
+        ca={
+            "environment_variable"="YT_SECURE_VAULT_YT_BUS_CA_BUNDLE";
+            "file_name"="/tls/ca_bundle/ca.crt";
+        };
+        "verification_mode"=full;
+        "peer_alternative_host_name"="fake.svc.cluster.local";
     };
     "master_cache"={
         addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ControllerAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ControllerAgent/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10014;
     "rpc_port"=9014;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/DataNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/DataNode/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10012;
     "rpc_port"=9012;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Discovery/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Discovery/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10020;
     "rpc_port"=9020;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[
@@ -109,7 +113,11 @@
     };
     "bus_client"={
         "encryption_mode"=required;
-        "verification_mode"=none;
+        ca={
+            "file_name"="/tls/ca_bundle/ca.crt";
+        };
+        "verification_mode"=full;
+        "peer_alternative_host_name"="fake.svc.cluster.local";
     };
     "discovery_server"={
         "server_addresses"=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ExecNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ExecNode/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10029;
     "rpc_port"=9029;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[
@@ -228,6 +232,13 @@
                 };
                 mode=simple;
             };
+            "environment_variables"=[
+                {
+                    name="YT_SECURE_VAULT_YT_BUS_CA_BUNDLE";
+                    "file_name"="/tls/ca_bundle/ca.crt";
+                    export=%false;
+                };
+            ];
             "cluster_connection"={
                 "cluster_name"=test;
                 "primary_master"={
@@ -251,7 +262,12 @@
                 };
                 "bus_client"={
                     "encryption_mode"=required;
-                    "verification_mode"=none;
+                    ca={
+                        "environment_variable"="YT_SECURE_VAULT_YT_BUS_CA_BUNDLE";
+                        "file_name"="/tls/ca_bundle/ca.crt";
+                    };
+                    "verification_mode"=full;
+                    "peer_alternative_host_name"="fake.svc.cluster.local";
                 };
                 "master_cache"={
                     addresses=[
@@ -272,7 +288,12 @@
             };
             "supervisor_connection"={
                 "encryption_mode"=required;
-                "verification_mode"=none;
+                ca={
+                    "environment_variable"="YT_SECURE_VAULT_YT_BUS_CA_BUNDLE";
+                    "file_name"="/tls/ca_bundle/ca.crt";
+                };
+                "verification_mode"=full;
+                "peer_alternative_host_name"="fake.svc.cluster.local";
                 address="127.0.0.1:9029";
             };
         };

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/HttpProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/HttpProxy/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10016;
     "rpc_port"=9016;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/KafkaProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/KafkaProxy/test.canondata
@@ -85,7 +85,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Master/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Master/test.canondata
@@ -68,7 +68,7 @@
     "monitoring_port"=10010;
     "rpc_port"=9010;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -105,7 +105,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[
@@ -132,7 +136,11 @@
     };
     "bus_client"={
         "encryption_mode"=required;
-        "verification_mode"=none;
+        ca={
+            "file_name"="/tls/ca_bundle/ca.crt";
+        };
+        "verification_mode"=full;
+        "peer_alternative_host_name"="fake.svc.cluster.local";
     };
     snapshots={
         path="/yt/master-data/master-snapshots";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/MasterCache/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/MasterCache/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10018;
     "rpc_port"=9018;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[
@@ -109,6 +113,10 @@
     };
     "bus_client"={
         "encryption_mode"=required;
-        "verification_mode"=none;
+        ca={
+            "file_name"="/tls/ca_bundle/ca.crt";
+        };
+        "verification_mode"=full;
+        "peer_alternative_host_name"="fake.svc.cluster.local";
     };
 }

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/NativeClientConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/NativeClientConfig/test.canondata
@@ -35,7 +35,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/QueryTracker/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/QueryTracker/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10028;
     "rpc_port"=9028;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/QueueAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/QueueAgent/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10030;
     "rpc_port"=9030;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[
@@ -109,7 +113,11 @@
     };
     "bus_client"={
         "encryption_mode"=required;
-        "verification_mode"=none;
+        ca={
+            "file_name"="/tls/ca_bundle/ca.crt";
+        };
+        "verification_mode"=full;
+        "peer_alternative_host_name"="fake.svc.cluster.local";
     };
     user="queue_agent";
     "queue_agent"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/RpcProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/RpcProxy/test.canondata
@@ -72,7 +72,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Scheduler/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Scheduler/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10011;
     "rpc_port"=9011;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/StrawberryController/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/StrawberryController/test.canondata
@@ -15,7 +15,7 @@
                 retries=1000;
             };
             "bus_server"={
-                "encryption_mode"=optional;
+                "encryption_mode"=required;
                 "cert_chain"={
                     "environment_variable"="YT_SECURE_VAULT_YT_BUS_SERVER_CERTIFICATE";
                     "file_name"="/tls/bus_secret/tls.crt";

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TabletNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TabletNode/test.canondata
@@ -45,7 +45,7 @@
     "monitoring_port"=10022;
     "rpc_port"=9022;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -82,7 +82,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TcpProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TcpProxy/test.canondata
@@ -72,7 +72,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/YqlAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/YqlAgent/test.canondata
@@ -58,7 +58,7 @@
     "monitoring_port"=10019;
     "rpc_port"=9019;
     "bus_server"={
-        "encryption_mode"=optional;
+        "encryption_mode"=required;
         "cert_chain"={
             "file_name"="/tls/bus_secret/tls.crt";
         };
@@ -95,7 +95,11 @@
         };
         "bus_client"={
             "encryption_mode"=required;
-            "verification_mode"=none;
+            ca={
+                "file_name"="/tls/ca_bundle/ca.crt";
+            };
+            "verification_mode"=full;
+            "peer_alternative_host_name"="fake.svc.cluster.local";
         };
         "master_cache"={
             addresses=[

--- a/pkg/ytconfig/generator_test.go
+++ b/pkg/ytconfig/generator_test.go
@@ -496,8 +496,9 @@ func TestGetYtsaurusWithTlsInterconnect(t *testing.T) {
 		TLSSecret: &corev1.LocalObjectReference{
 			Name: "ytsaurus-native-cert",
 		},
-		TLSRequired:                true,
-		TLSInsecure:                true,                                 // not mTLS
+		TLSRequired: true, // client and server requires TLS
+		TLSInsecure: true, // no mTLS
+
 		TLSPeerAlternativeHostName: testNamespace + ".svc.cluster.local", // or testNamespace.testClusterDomain ?
 	}
 
@@ -529,7 +530,9 @@ func TestGetYtsaurusWithMutualTLSInterconnect(t *testing.T) {
 		TLSClientSecret: &corev1.LocalObjectReference{
 			Name: "ytsaurus-native-client-cert",
 		},
-		TLSRequired:                true,
+		TLSRequired: true,  // client and server requires TLS
+		TLSInsecure: false, // mTLS
+
 		TLSPeerAlternativeHostName: testNamespace + ".svc.cluster.local",
 	}
 

--- a/ytop-chart/templates/crds/remotedatanodes.cluster.ytsaurus.tech.yaml
+++ b/ytop-chart/templates/crds/remotedatanodes.cluster.ytsaurus.tech.yaml
@@ -991,14 +991,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls

--- a/ytop-chart/templates/crds/remoteexecnodes.cluster.ytsaurus.tech.yaml
+++ b/ytop-chart/templates/crds/remoteexecnodes.cluster.ytsaurus.tech.yaml
@@ -1181,14 +1181,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls

--- a/ytop-chart/templates/crds/remotetabletnodes.cluster.ytsaurus.tech.yaml
+++ b/ytop-chart/templates/crds/remotetabletnodes.cluster.ytsaurus.tech.yaml
@@ -991,14 +991,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls

--- a/ytop-chart/templates/crds/remoteytsaurus.cluster.ytsaurus.tech.yaml
+++ b/ytop-chart/templates/crds/remoteytsaurus.cluster.ytsaurus.tech.yaml
@@ -932,14 +932,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls

--- a/ytop-chart/templates/crds/ytsaurus.cluster.ytsaurus.tech.yaml
+++ b/ytop-chart/templates/crds/ytsaurus.cluster.ytsaurus.tech.yaml
@@ -1020,15 +1020,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -3595,15 +3596,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -6178,15 +6180,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -8767,15 +8770,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -11580,15 +11584,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -14208,15 +14213,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -16839,15 +16845,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -19437,15 +19444,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -21144,14 +21152,15 @@ spec:
                     type: object
                     x-kubernetes-map-type: atomic
                   tlsInsecure:
-                    description: Disable TLS certificate verification.
+                    description: 'Disable client certificate verification when TLS
+                      is required, if not required - '
                     type: boolean
                   tlsPeerAlternativeHostName:
                     description: Define alternative host name for certificate verification.
                     type: string
                   tlsRequired:
-                    description: Require encrypted connections, otherwise only when
-                      required by peer.
+                    description: Require secure TLS connections by server, otherwise
+                      only by client.
                     type: boolean
                   tlsSecret:
                     description: Server certificate. Reference to kubernetes.io/tls
@@ -22105,15 +22114,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -24690,15 +24700,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -27261,15 +27272,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -29840,15 +29852,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -30058,15 +30071,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -32465,15 +32479,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls
@@ -35061,15 +35076,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -37798,15 +37814,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -40398,15 +40415,16 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                         tlsInsecure:
-                          description: Disable TLS certificate verification.
+                          description: 'Disable client certificate verification when
+                            TLS is required, if not required - '
                           type: boolean
                         tlsPeerAlternativeHostName:
                           description: Define alternative host name for certificate
                             verification.
                           type: string
                         tlsRequired:
-                          description: Require encrypted connections, otherwise only
-                            when required by peer.
+                          description: Require secure TLS connections by server, otherwise
+                            only by client.
                           type: boolean
                         tlsSecret:
                           description: Server certificate. Reference to kubernetes.io/tls
@@ -43325,15 +43343,16 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       tlsInsecure:
-                        description: Disable TLS certificate verification.
+                        description: 'Disable client certificate verification when
+                          TLS is required, if not required - '
                         type: boolean
                       tlsPeerAlternativeHostName:
                         description: Define alternative host name for certificate
                           verification.
                         type: string
                       tlsRequired:
-                        description: Require encrypted connections, otherwise only
-                          when required by peer.
+                        description: Require secure TLS connections by server, otherwise
+                          only by client.
                         type: boolean
                       tlsSecret:
                         description: Server certificate. Reference to kubernetes.io/tls


### PR DESCRIPTION
```
     +-------------+-------------+----------+--------+--------+
     | tlsRequired | tlsInsecure |   TLS    | server | client |
     +-------------+-------------+----------+--------+--------+
     | false       | true        | no       | EO-VN  | EO-VN  |
     | false       | false       | yes      | EO-VN  | ER-VF  |
     | true        | true        | tls-only | ER-VN  | ER-VF  |
     | true        | false       | mutual   | ER-VF  | ER-VF  |
     +-------------+-------------+----------+--------+--------+
```
  EO = Encryption Optional
  ER = Encryption Required
  VN = Verification None
  VF = Verification Full

Link: https://github.com/ytsaurus/ytsaurus-k8s-operator/issues/536
Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
