### PR TITLE
Fix cypress patch updating logic

### DIFF
--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -886,7 +886,6 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				By("Waiting cluster update starts")
 				EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveClusterStateUpdating())
 				Expect(ytsaurus).Should(HaveClusterUpdatingComponents(
-					consts.YtsaurusClientType, // to update overrides version in cypress patch.
 					consts.DiscoveryType,
 					consts.ExecNodeType,
 				)) // change in containerd.toml must trigger exec node update


### PR DESCRIPTION
- generate and apply missing patch during init and reconfigure
- update component patch when saved state is missing
- describe reason why action is required

Signed-off-by: Konstantin Khlebnikov <khlebnikov@tracto.ai>
