### PR TITLE
Fix: Sidecar crashes during initialization lead to pods not being able to initialize

### DIFF
--- a/pkg/components/canondata/TestGetTimbertruckSupervisorScript/test.canondata
+++ b/pkg/components/canondata/TestGetTimbertruckSupervisorScript/test.canondata
@@ -1,4 +1,7 @@
-mkdir -p /etc/timbertruck; echo 'json_logs:
+
+mkdir -p /etc/timbertruck
+cat <<'EOF' > /etc/timbertruck/config.yaml
+json_logs:
 - log_file: /yt/master-logs/master.access.log.json
   name: master-access
   yt_queue:
@@ -18,4 +21,14 @@ mkdir -p /etc/timbertruck; echo 'json_logs:
     producer_path: //sys/admin/logs/master-other/producer
     queue_path: //sys/admin/logs/master-other/queue
 work_dir: /yt/master-logs/timbertruck
-' > /etc/timbertruck/config.yaml; chmod 644 /etc/timbertruck/config.yaml; /usr/bin/timbertruck_os -config /etc/timbertruck/config.yaml
+
+EOF
+chmod 644 /etc/timbertruck/config.yaml
+echo "Starting timbertruck supervisor loop..."
+while true; do
+	/usr/bin/timbertruck_os -config /etc/timbertruck/config.yaml &
+	PID=$!
+	wait $PID
+	echo "timbertruck process with PID $PID exited. Restarting in 10 seconds..."
+	sleep 10
+done

--- a/pkg/components/helpers.go
+++ b/pkg/components/helpers.go
@@ -22,9 +22,6 @@ import (
 	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/apiproxy"
 )
 
-const timbertruckInitScriptPrefix = "mkdir -p /etc/timbertruck; echo '"
-const timbertruckInitScriptSuffix = "' > /etc/timbertruck/config.yaml; chmod 644 /etc/timbertruck/config.yaml; /usr/bin/timbertruck_os -config /etc/timbertruck/config.yaml"
-
 func CreateTabletCells(ctx context.Context, ytClient yt.Client, bundle string, tabletCellCount int) error {
 	logger := log.FromContext(ctx)
 

--- a/pkg/components/timbertruck_test.go
+++ b/pkg/components/timbertruck_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/ytconfig"
 )
 
-func TestGetTimbertruckInitScript(t *testing.T) {
+func TestGetTimbertruckSupervisorScript(t *testing.T) {
 	timbertruckConfig := ytconfig.NewTimbertruckConfig(
 		[]v1.StructuredLoggerSpec{
 			{
@@ -44,7 +44,7 @@ func TestGetTimbertruckInitScript(t *testing.T) {
 		"http-proxies-lb.ytsaurus-dev.svc.cluster.local",
 		"//sys/admin/logs",
 	)
-	timbertruckInitScript, err := getTimbertruckInitScript(timbertruckConfig)
+	timbertruckSupervisorScript, err := getTimbertruckSupervisorScript(timbertruckConfig)
 	require.NoError(t, err)
-	canonize.Assert(t, []byte(timbertruckInitScript))
+	canonize.Assert(t, []byte(timbertruckSupervisorScript))
 }


### PR DESCRIPTION
If any of the sidecars fails to start during master startup (for example, due to insufficient disk space to initialize the sidecars' working directories), the container will be marked as crashed, and therefore the pod will not be considered "running." Although the master will continue to run, other pods will be unable to access it, as the Kubernetes DNS prevents other pods from accessing the master. The operator will also be unable to continue cluster startup because it will not be able to wait for the pod to reach the "running" state.

Therefore, a supervisor was added for sidecars, which prevents the container from crashing and automatically restarts the binary.