### PR TITLE
Use short name to fix a too long service name

### DIFF
--- a/ytop-chart/templates/metrics-cert.yaml
+++ b/ytop-chart/templates/metrics-cert.yaml
@@ -1,7 +1,7 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "ytop-chart.name" . }}-metrics-cert
+  name: {{ include "ytop-chart.fullname" . }}-metrics-cert
   labels:
   {{- include "ytop-chart.labels" . | nindent 4 }}
 spec:

--- a/ytop-chart/templates/metrics-cert.yaml
+++ b/ytop-chart/templates/metrics-cert.yaml
@@ -1,14 +1,14 @@
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: {{ include "ytop-chart.fullname" . }}-metrics-cert
+  name: {{ include "ytop-chart.name" . }}-metrics-cert
   labels:
   {{- include "ytop-chart.labels" . | nindent 4 }}
 spec:
   dnsNames:
-  - '{{ include "ytop-chart.fullname" . }}-controller-manager-metrics-service.{{ .Release.Namespace
+  - '{{ include "ytop-chart.name" . }}-controller-manager-metrics-service.{{ .Release.Namespace
     }}.svc'
-  - '{{ include "ytop-chart.fullname" . }}-controller-manager-metrics-service.{{ .Release.Namespace
+  - '{{ include "ytop-chart.name" . }}-controller-manager-metrics-service.{{ .Release.Namespace
     }}.svc.{{ .Values.kubernetesClusterDomain }}'
   issuerRef:
     kind: Issuer

--- a/ytop-chart/templates/metrics-service.yaml
+++ b/ytop-chart/templates/metrics-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "ytop-chart.fullname" . }}-controller-manager-metrics-service
+  name: {{ include "ytop-chart.name" . }}-controller-manager-metrics-service
   labels:
     control-plane: controller-manager
   {{- include "ytop-chart.labels" . | nindent 4 }}


### PR DESCRIPTION
Now, I have a problem in my k8s, when I try install yt operator from nightly build:

```
Error: UPGRADE FAILED: failed to create resource: Service "ytop-release-ytop-chart-nightly-controller-manager-metrics-service" is invalid: metadata.name: Invalid value: "ytop-release-ytop-chart-nightly-controller-manager-metrics-service": must be no more than 63 characters
```