### PR TITLE
Added HasCustomUpdateState in order to migrate qt,qa,yqla and sch to the common handleUpdatingClusterState

### DIFF
--- a/pkg/components/bundle_controller.go
+++ b/pkg/components/bundle_controller.go
@@ -89,3 +89,7 @@ func (bc *BundleController) Sync(ctx context.Context) error {
 func (bc *BundleController) doServerSync(ctx context.Context) error {
 	return bc.server.Sync(ctx)
 }
+
+func (bc *BundleController) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/component.go
+++ b/pkg/components/component.go
@@ -84,6 +84,7 @@ type Component interface {
 	GetLabeller() *labeller.Labeller
 
 	GetCypressPatch() ypatch.PatchSet
+	HasCustomUpdateState() bool
 }
 
 // Following structs are used as a base for implementing YTsaurus components objects.

--- a/pkg/components/controller_agent.go
+++ b/pkg/components/controller_agent.go
@@ -91,3 +91,7 @@ func (ca *ControllerAgent) Sync(ctx context.Context) error {
 	_, err := ca.doSync(ctx, false)
 	return err
 }
+
+func (ca *ControllerAgent) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/cypressproxy.go
+++ b/pkg/components/cypressproxy.go
@@ -85,3 +85,7 @@ func (cyp *CypressProxy) Sync(ctx context.Context) error {
 func (cyp *CypressProxy) doServerSync(ctx context.Context) error {
 	return cyp.server.Sync(ctx)
 }
+
+func (cyp *CypressProxy) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/data_node.go
+++ b/pkg/components/data_node.go
@@ -124,3 +124,7 @@ func (n *DataNode) handleImaginaryChunksMigration(ctx context.Context, dry bool)
 	}
 	return ptr.To(ComponentStatusUpdateStep("pods removal for imaginary chunks migration")), err
 }
+
+func (n *DataNode) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/discovery.go
+++ b/pkg/components/discovery.go
@@ -83,3 +83,7 @@ func (d *Discovery) Sync(ctx context.Context) error {
 	_, err := d.doSync(ctx, false)
 	return err
 }
+
+func (d *Discovery) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/exec_node.go
+++ b/pkg/components/exec_node.go
@@ -115,3 +115,7 @@ func (n *ExecNode) Sync(ctx context.Context) error {
 	_, err := n.doSync(ctx, false)
 	return err
 }
+
+func (n *ExecNode) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/helpers.go
+++ b/pkg/components/helpers.go
@@ -172,7 +172,8 @@ func handleUpdatingClusterState(
 			return ptr.To(ComponentStatusUpdateStep("pods removal")), err
 		}
 
-		if ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForPodsCreation {
+		if ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForPodsCreation &&
+			!cmp.HasCustomUpdateState() {
 			return ptr.To(ComponentStatusReady()), err
 		}
 	} else {

--- a/pkg/components/httpproxy.go
+++ b/pkg/components/httpproxy.go
@@ -182,3 +182,7 @@ func (hp *HttpProxy) Sync(ctx context.Context) error {
 	_, err := hp.doSync(ctx, false)
 	return err
 }
+
+func (hp *HttpProxy) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/kafka_proxy.go
+++ b/pkg/components/kafka_proxy.go
@@ -134,3 +134,7 @@ func (kp *KafkaProxy) Sync(ctx context.Context) error {
 	_, err := kp.doSync(ctx, false)
 	return err
 }
+
+func (kp *KafkaProxy) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -676,3 +676,7 @@ func addHydraPersistenceUploaderToPodSpec(hydraImage string, podSpec *corev1.Pod
 		},
 	)
 }
+
+func (m *Master) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/master_caches.go
+++ b/pkg/components/master_caches.go
@@ -99,3 +99,7 @@ func (mc *MasterCache) getHostAddressLabel() string {
 	}
 	return defaultHostAddressLabel
 }
+
+func (mc *MasterCache) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/offshore_data_gateway.go
+++ b/pkg/components/offshore_data_gateway.go
@@ -80,3 +80,7 @@ func (p *OffshoreDataGateway) Sync(ctx context.Context) (ComponentStatus, error)
 func (p *OffshoreDataGateway) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx, p.server)
 }
+
+func (p *OffshoreDataGateway) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/query_tracker.go
+++ b/pkg/components/query_tracker.go
@@ -450,3 +450,7 @@ func (qt *QueryTracker) setConditionQTStateUpdated(ctx context.Context) {
 		Message: "Query tracker state updated",
 	})
 }
+
+func (qt *QueryTracker) HasCustomUpdateState() bool {
+	return true
+}

--- a/pkg/components/queue_agent.go
+++ b/pkg/components/queue_agent.go
@@ -414,3 +414,7 @@ func (qa *QueueAgent) Sync(ctx context.Context) error {
 	_, err := qa.doSync(ctx, false)
 	return err
 }
+
+func (qa *QueueAgent) HasCustomUpdateState() bool {
+	return true
+}

--- a/pkg/components/rpcproxy.go
+++ b/pkg/components/rpcproxy.go
@@ -172,3 +172,7 @@ func (rp *RpcProxy) Sync(ctx context.Context) error {
 	_, err := rp.doSync(ctx, false)
 	return err
 }
+
+func (rp *RpcProxy) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/scheduler.go
+++ b/pkg/components/scheduler.go
@@ -124,24 +124,16 @@ func (s *Scheduler) doSync(ctx context.Context, dry bool) (ComponentStatus, erro
 	}
 
 	if s.ytsaurus.GetClusterState() == ytv1.ClusterStateUpdating {
-		if IsUpdatingComponent(s.ytsaurus, s) {
-			if s.ytsaurus.GetUpdateState() == ytv1.UpdateStateWaitingForPodsRemoval {
-				if !dry {
-					err = removePods(ctx, s.server, &s.localComponent)
-				}
-				return ComponentStatusUpdateStep("pods removal"), err
-			}
+		if status, err := handleUpdatingClusterState(ctx, s.ytsaurus, s, &s.localComponent, s.server, dry); status != nil {
+			return *status, err
+		}
+		if status, err := s.updateOpArchive(ctx, dry); status != nil {
+			return *status, err
+		}
 
-			if status, err := s.updateOpArchive(ctx, dry); status != nil {
-				return *status, err
-			}
-
-			if s.ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForPodsCreation &&
-				s.ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForOpArchiveUpdate {
-				return ComponentStatusReady(), err
-			}
-		} else {
-			return ComponentStatusReadyAfter("Not updating component"), err
+		if s.ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForPodsCreation &&
+			s.ytsaurus.GetUpdateState() != ytv1.UpdateStateWaitingForOpArchiveUpdate {
+			return ComponentStatusReady(), err
 		}
 	}
 
@@ -312,4 +304,8 @@ func (s *Scheduler) prepareInitOperationsArchive() {
 	job := s.initOpArchiveJob.Build()
 	container := &job.Spec.Template.Spec.Containers[0]
 	container.EnvFrom = []corev1.EnvFromSource{s.secret.GetEnvSource()}
+}
+
+func (s *Scheduler) HasCustomUpdateState() bool {
+	return true
 }

--- a/pkg/components/strawberry_controller.go
+++ b/pkg/components/strawberry_controller.go
@@ -365,3 +365,7 @@ func (c *StrawberryController) Sync(ctx context.Context) error {
 	_, err := c.doSync(ctx, false)
 	return err
 }
+
+func (c *StrawberryController) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/suite_test.go
+++ b/pkg/components/suite_test.go
@@ -87,6 +87,10 @@ func (fc *FakeComponent) GetCypressPatch() ypatch.PatchSet {
 
 func (fc *FakeComponent) SetReadyCondition(status ComponentStatus) {}
 
+func (fc *FakeComponent) HasCustomUpdateState() bool {
+	return false
+}
+
 type FakeServer struct {
 	podsReady bool
 }

--- a/pkg/components/tablet_node.go
+++ b/pkg/components/tablet_node.go
@@ -258,3 +258,7 @@ func (tn *TabletNode) Sync(ctx context.Context) error {
 func (tn *TabletNode) Fetch(ctx context.Context) error {
 	return resources.Fetch(ctx, tn.server)
 }
+
+func (tn *TabletNode) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/tcpproxy.go
+++ b/pkg/components/tcpproxy.go
@@ -118,3 +118,7 @@ func (tp *TcpProxy) Sync(ctx context.Context) error {
 	_, err := tp.doSync(ctx, false)
 	return err
 }
+
+func (tp *TcpProxy) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/timbertruck.go
+++ b/pkg/components/timbertruck.go
@@ -489,3 +489,7 @@ func checkAndAddTimbertruckToServerOptions(options *[]Option, timbertruck *ytv1.
 		))
 	}
 }
+
+func (tt *Timbertruck) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/ui.go
+++ b/pkg/components/ui.go
@@ -337,3 +337,7 @@ func (u *UI) Sync(ctx context.Context) error {
 	_, err := u.doSync(ctx, false)
 	return err
 }
+
+func (u *UI) HasCustomUpdateState() bool {
+	return false
+}

--- a/pkg/components/yql_agent.go
+++ b/pkg/components/yql_agent.go
@@ -272,3 +272,7 @@ func (yqla *YqlAgent) Sync(ctx context.Context) error {
 	_, err := yqla.doSync(ctx, false)
 	return err
 }
+
+func (yqla *YqlAgent) HasCustomUpdateState() bool {
+	return true
+}

--- a/pkg/components/ytsaurus_client.go
+++ b/pkg/components/ytsaurus_client.go
@@ -952,3 +952,7 @@ func (yc *YtsaurusClient) areActiveDataNodesWithImaginaryChunksExist(ctx context
 	)
 	return true, nil
 }
+
+func (yc *YtsaurusClient) HasCustomUpdateState() bool {
+	return false
+}


### PR DESCRIPTION
In that [PR](https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/601) I created a bug. qt, qa, yqla and sch components have their own additional logic during the update. [updateQTState](https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/606/files#diff-8de26e1e52d4bdfeb4d2cea625c03860851a33787654f5951ea7719df9896adbR104) for qt, [updateYqla](https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/606/files#diff-e8c177ec5552f16b5c1d0b28e41d7e3f6023672e05ad86de72535bd8dcad4cedR158) for yqla, etc. In the [PR](https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/601) I made those additional logic unreachable, because `handleUpdatingClusterState` returns a non-nil status (`ComponentStatusReady()`), the [updateQTState](https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/606/files#diff-8de26e1e52d4bdfeb4d2cea625c03860851a33787654f5951ea7719df9896adbR412)() function is never called, which means `prepareRestart()` is never executed. It lead to a situation when ytsaurus cluster stuck in Updating status indefinitely.
Current PR is fixing that issue by introducing [HasCustomUpdateState](https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/606/files#diff-df79516caab9f32d7a036081e9d1477e22679a71aa5dbf99f7d2889f081dc5a2R87) method of the Component Interface and adding small `if` [here](https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/606/files#diff-568998f3afe3b99cf89ffd554a0038cc17f8f747615d1a06fec01a336d20f779R175).
It's better to fix it that way then rolling back the [PR](https://github.com/ytsaurus/ytsaurus-k8s-operator/pull/601), because `handleUpdatingClusterState` will be used later in the rollingUpdate logic. And also it reduce code duplication in qt, qa, yqla and sch components.

