### PR TITLE
Added Class update support for the new rolling update, adjusted webhooks and tests for that.

### DIFF
--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -34814,6 +34814,7 @@ spec:
                       - ""
                       - Nothing
                       - Stateless
+                      - StatefulAgents
                       - Everything
                       type: string
                     component:

--- a/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
@@ -40607,6 +40607,7 @@
                   "",
                   "Nothing",
                   "Stateless",
+                  "StatefulAgents",
                   "Everything"
                 ]
               },

--- a/controllers/sync.go
+++ b/controllers/sync.go
@@ -18,17 +18,11 @@ import (
 func canUpdateComponent(selectors []ytv1.ComponentUpdateSelector, component ytv1.Component) bool {
 	for _, selector := range selectors {
 		if selector.Class != consts.ComponentClassUnspecified {
-			switch selector.Class {
-			case consts.ComponentClassEverything:
+			if selector.Class == consts.ComponentClassNothing {
+				return false
+			}
+			if ytv1.ComponentBelongsToClass(component.Type, selector.Class) {
 				return true
-			case consts.ComponentClassNothing:
-				return false
-			case consts.ComponentClassStateless:
-				if component.Type != consts.DataNodeType && component.Type != consts.TabletNodeType && component.Type != consts.MasterType {
-					return true
-				}
-			default:
-				return false
 			}
 		}
 		if selector.Component.Type == component.Type && (selector.Component.Name == "" || selector.Component.Name == component.Name) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -502,7 +502,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `class` _[ComponentClass](#componentclass)_ |  |  | Enum: [ Nothing Stateless Everything] <br /> |
+| `class` _[ComponentClass](#componentclass)_ |  |  | Enum: [ Nothing Stateless StatefulAgents Everything] <br /> |
 | `component` _[Component](#component)_ |  |  |  |
 | `strategy` _[ComponentUpdateStrategy](#componentupdatestrategy)_ |  |  |  |
 

--- a/pkg/apiproxy/ytsaurus.go
+++ b/pkg/apiproxy/ytsaurus.go
@@ -106,15 +106,14 @@ func (c *Ytsaurus) ShouldRunPreChecks(componentType consts.ComponentType, compon
 }
 
 func (c *Ytsaurus) shouldEnablePreChecksFromSpec(componentType consts.ComponentType, componentName string) bool {
-	for _, selector := range c.ytsaurus.Spec.UpdatePlan {
-		if selector.Component.Type == componentType &&
-			(selector.Component.Name == "" || selector.Component.Name == componentName) {
-			if selector.Strategy != nil {
-				return ptr.Deref(selector.Strategy.RunPreChecks, true)
-			}
-		}
+	strategy := ytv1.ResolveComponentUpdateStrategy(
+		c.ytsaurus.Spec.UpdatePlan,
+		ytv1.Component{Type: componentType, Name: componentName},
+	)
+	if strategy == nil {
+		return true
 	}
-	return true
+	return ptr.Deref(strategy.RunPreChecks, true)
 }
 
 func (c *Ytsaurus) SetBlockedComponents(components []ytv1.Component) bool {

--- a/pkg/consts/types.go
+++ b/pkg/consts/types.go
@@ -36,10 +36,11 @@ type ComponentClass string
 
 const (
 	// ComponentClassStateless group contains only stateless components (not master, data nodes, tablet nodes)
-	ComponentClassUnspecified ComponentClass = ""
-	ComponentClassStateless   ComponentClass = "Stateless"
-	ComponentClassEverything  ComponentClass = "Everything"
-	ComponentClassNothing     ComponentClass = "Nothing"
+	ComponentClassUnspecified    ComponentClass = ""
+	ComponentClassStateless      ComponentClass = "Stateless"
+	ComponentClassStatefulAgents ComponentClass = "StatefulAgents"
+	ComponentClassEverything     ComponentClass = "Everything"
+	ComponentClassNothing        ComponentClass = "Nothing"
 )
 
 var (

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -34819,6 +34819,7 @@ spec:
                       - ""
                       - Nothing
                       - Stateless
+                      - StatefulAgents
                       - Everything
                       type: string
                     component:


### PR DESCRIPTION
- UpdatePlan now supports class‑based strategy resolution via `ComponentBelongsToClass`/`ResolveComponentUpdateStrategy`, and `ComponentClassStatefulAgents`.
- Webhook validation updated to allow class selectors with strategies, enforce class restrictions (StatefulAgents/Everything only BulkUpdate), and rewire validation paths;
- Tests added for class strategy validation and class bulk update flow.