### PR TITLE
pkg/ypatch: handle setting attribute with missing parent

### DIFF
--- a/pkg/ypatch/apply.go
+++ b/pkg/ypatch/apply.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"go.ytsaurus.tech/yt/go/ypath"
 	"go.ytsaurus.tech/yt/go/yt"
+	"go.ytsaurus.tech/yt/go/yterrors"
 )
 
 type PatchTarget interface {
@@ -25,6 +27,39 @@ func ypathIsAbsolute(path ypath.Path) bool {
 	return err == nil && tokens[0] == string(ypath.Root)
 }
 
+func (t *CypressPatchTarget) SetNode(ctx context.Context, dst ypath.YPath, value any, options *yt.SetNodeOptions) error {
+retry:
+	err := t.Client.SetNode(ctx, dst, value, options)
+
+	// Handle recursion when setting nested attributes without parents.
+	// Workaround for bug: https://github.com/ytsaurus/ytsaurus/issues/1729
+	// NOTE: Does not handle setting all attributes at once "/@", "/begin", "/end", etc.
+	// NOTE: Will loose path attributes for Rich path argument due to ypath design flaw.
+	if err != nil && yterrors.ContainsResolveError(err) && options != nil && options.Recursive && strings.Contains(string(dst.YPath()), "/@") {
+		parent, child, err2 := ypath.Split(dst.YPath())
+		if err2 != nil {
+			return err2
+		}
+		// SetNode node/@parent/child value -> SetNode node/@parent {child=value}
+		if !strings.HasPrefix(child, "/@") {
+			dst = parent
+			value = map[string]any{child[1:]: value}
+			goto retry
+		}
+		// SetNode parent/@child value -> CreateNode parent {child=value}
+		_, err = t.Client.CreateNode(ctx, parent, yt.NodeMap, &yt.CreateNodeOptions{
+			Recursive:             true,
+			Attributes:            map[string]any{child[2:]: value},
+			TransactionOptions:    options.TransactionOptions,
+			AccessTrackingOptions: options.AccessTrackingOptions,
+			MutatingOptions:       options.MutatingOptions,
+			PrerequisiteOptions:   options.PrerequisiteOptions,
+		})
+	}
+
+	return err
+}
+
 func (t *CypressPatchTarget) ApplyPatch(ctx context.Context, path ypath.Path, patch Patch) error {
 	setOpts := &yt.SetNodeOptions{
 		Recursive: true,  // Create parents
@@ -40,8 +75,8 @@ func (t *CypressPatchTarget) ApplyPatch(ctx context.Context, path ypath.Path, pa
 		switch op.Op {
 		case PatchOpAdd, PatchOpReplace:
 			if !t.DryRun {
-				// FIXME: check non existence or add.
-				err = t.Client.SetNode(ctx, dst, op.Value, setOpts)
+				// FIXME: check non existence on add.
+				err = t.SetNode(ctx, dst, op.Value, setOpts)
 			}
 		case PatchOpCopy, PatchOpMove:
 			src := op.From
@@ -53,7 +88,7 @@ func (t *CypressPatchTarget) ApplyPatch(ctx context.Context, path ypath.Path, pa
 				break
 			}
 			if !t.DryRun {
-				if err = t.Client.SetNode(ctx, dst, tmp, setOpts); err != nil {
+				if err = t.SetNode(ctx, dst, tmp, setOpts); err != nil {
 					break
 				}
 				if op.Op == PatchOpMove {

--- a/pkg/ypatch/apply_test.go
+++ b/pkg/ypatch/apply_test.go
@@ -1,0 +1,130 @@
+package ypatch
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"go.ytsaurus.tech/yt/go/ypath"
+	"go.ytsaurus.tech/yt/go/yt"
+	"go.ytsaurus.tech/yt/go/yterrors"
+
+	mock_yt "github.com/ytsaurus/ytsaurus-k8s-operator/pkg/mock"
+)
+
+func TestCypressPatchTargetApplyPatchCommonCases(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+	client := mock_yt.NewMockClient(ctrl)
+	target := CypressPatchTarget{Client: client}
+
+	setOpts := &yt.SetNodeOptions{Recursive: true, Force: false}
+	removeOpts := &yt.RemoveNodeOptions{Recursive: true, Force: true}
+	copiedValue := "copied-value"
+	movedValue := "moved-value"
+	testValue := map[string]any{"ok": true}
+
+	gomock.InOrder(
+		client.EXPECT().SetNode(ctx, ypath.Path("//added"), "new-value", setOpts),
+		client.EXPECT().SetNode(ctx, ypath.Path("//replaced"), map[string]any{"answer": 42}, setOpts),
+		client.EXPECT().GetNode(ctx, ypath.Path("//source"), gomock.Any(), nil).DoAndReturn(nodeResult(copiedValue)),
+		client.EXPECT().SetNode(ctx, ypath.Path("//copied"), copiedValue, setOpts),
+		client.EXPECT().GetNode(ctx, ypath.Path("//move"), gomock.Any(), nil).DoAndReturn(nodeResult(movedValue)),
+		client.EXPECT().SetNode(ctx, ypath.Path("//moved"), movedValue, setOpts),
+		client.EXPECT().RemoveNode(ctx, ypath.Path("//move"), removeOpts),
+		client.EXPECT().RemoveNode(ctx, ypath.Path("//remove"), removeOpts),
+		client.EXPECT().GetNode(ctx, ypath.Path("//check"), gomock.Any(), nil).DoAndReturn(nodeResult(testValue)),
+	)
+
+	patch := Patch{
+		Add("//added", "new-value"),
+		Replace("//replaced", map[string]any{"answer": 42}),
+		Copy("//copied", "//source"),
+		Move("//moved", "//move"),
+		Remove("//remove"),
+		Test("//check", testValue),
+	}
+
+	if err := target.ApplyPatch(ctx, "", patch); err != nil {
+		t.Fatalf("ApplyPatch() failed: %v", err)
+	}
+}
+
+func TestCypressPatchTargetApplyPatchSetUsesSortedPaths(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+	client := mock_yt.NewMockClient(ctrl)
+	target := CypressPatchTarget{Client: client}
+
+	setOpts := &yt.SetNodeOptions{Recursive: true, Force: false}
+	gomock.InOrder(
+		client.EXPECT().SetNode(ctx, ypath.Path("//a/value"), 1, setOpts),
+		client.EXPECT().SetNode(ctx, ypath.Path("//b/value"), 2, setOpts),
+	)
+
+	patchSet := PatchSet{
+		"//b": {Replace("/value", 2)},
+		"//a": {Replace("/value", 1)},
+	}
+
+	if err := target.ApplyPatchSet(ctx, "", patchSet); err != nil {
+		t.Fatalf("ApplyPatchSet() failed: %v", err)
+	}
+}
+
+func TestCypressPatchTargetSetNodeWhenParentAttributeIsMissing(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+	client := mock_yt.NewMockClient(ctrl)
+	target := CypressPatchTarget{Client: client}
+
+	setOpts := &yt.SetNodeOptions{Recursive: true, Force: false}
+	value := map[string]any{"node_count": 10}
+	value2 := map[string]any{"child": value}
+	resolveErr := &yterrors.Error{Code: yterrors.CodeResolveError, Message: "missing parent attribute"}
+
+	gomock.InOrder(
+		client.EXPECT().SetNode(ctx, ypath.Path("//path/node/@parent/child"), value, setOpts).Return(resolveErr),
+		client.EXPECT().SetNode(ctx, ypath.Path("//path/node/@parent"), value2, setOpts).Return(nil),
+	)
+
+	if err := target.ApplyPatch(ctx, "", Patch{Replace("//path/node/@parent/child", value)}); err != nil {
+		t.Fatalf("ApplyPatch() failed: %v", err)
+	}
+}
+
+func TestCypressPatchTargetSetNodeWhenNodeIsMissing(t *testing.T) {
+	ctx := t.Context()
+	ctrl := gomock.NewController(t)
+	client := mock_yt.NewMockClient(ctrl)
+	target := CypressPatchTarget{Client: client}
+
+	setOpts := &yt.SetNodeOptions{Recursive: true, Force: false}
+	value := map[string]any{"node_count": 10}
+	value2 := map[string]any{"child": value}
+	value3 := map[string]any{"parent": value2}
+	resolveErr := &yterrors.Error{Code: yterrors.CodeResolveError, Message: "missing parent attribute"}
+
+	gomock.InOrder(
+		client.EXPECT().SetNode(ctx, ypath.Path("//path/node/@parent/child"), value, setOpts).Return(resolveErr),
+		client.EXPECT().SetNode(ctx, ypath.Path("//path/node/@parent"), value2, setOpts).Return(resolveErr),
+		client.EXPECT().CreateNode(
+			ctx,
+			ypath.Path("//path/node"),
+			yt.NodeMap,
+			&yt.CreateNodeOptions{Recursive: true, Attributes: value3},
+		).Return(yt.NodeID{}, nil),
+	)
+
+	if err := target.ApplyPatch(ctx, "", Patch{Replace("//path/node/@parent/child", value)}); err != nil {
+		t.Fatalf("ApplyPatch() failed: %v", err)
+	}
+}
+
+func nodeResult(value any) func(context.Context, ypath.YPath, any, *yt.GetNodeOptions) error {
+	return func(_ context.Context, _ ypath.YPath, result any, _ *yt.GetNodeOptions) error {
+		reflect.ValueOf(result).Elem().Set(reflect.ValueOf(value))
+		return nil
+	}
+}


### PR DESCRIPTION
Operation "set" for nested attribute with option recursive=true
cannot create missing parent attribute, node or parent node.

Link: https://github.com/ytsaurus/ytsaurus/issues/1729
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
