### PR TITLE
Fix "Conflicting profiling tags" alert at tablet nodes

### DIFF
--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -43,6 +43,10 @@ type NodeGenerator struct {
 
 	discoveryInstanceCount int32
 	dataNodesInstanceCount int32
+
+	// Number of bundle controller instances on the cluster. Nil means the
+	// information is not available (e.g. for remote node generators).
+	bundleControllerInstanceCount *int32
 }
 
 type Generator struct {
@@ -66,6 +70,11 @@ func NewLocalNodeGenerator(
 	var dataNodesInstanceCount int32
 	for _, dataNodes := range ytsaurus.Spec.DataNodes {
 		dataNodesInstanceCount += dataNodes.InstanceCount
+	}
+
+	var bundleControllerInstanceCount int32
+	if spec := ytsaurus.Spec.BundleController; spec != nil {
+		bundleControllerInstanceCount = spec.InstanceCount
 	}
 
 	primaryMaster := masterCellInfo{
@@ -102,14 +111,15 @@ func NewLocalNodeGenerator(
 			Annotations:   ytsaurus.Spec.ExtraPodAnnotations,
 			UseShortNames: ytsaurus.Spec.UseShortNames,
 		},
-		commonSpec:             &ytsaurus.Spec.CommonSpec,
-		clusterFeatures:        ptr.Deref(ytsaurus.Spec.ClusterFeatures, ytv1.ClusterFeatures{}),
-		primaryMaster:          primaryMaster,
-		secondaryMasters:       secondaryMasters,
-		masterCache:            masterCache,
-		discoveryInstanceCount: ytsaurus.Spec.Discovery.InstanceCount,
-		cypressProxiesSpec:     ytsaurus.Spec.CypressProxies,
-		dataNodesInstanceCount: dataNodesInstanceCount,
+		commonSpec:                    &ytsaurus.Spec.CommonSpec,
+		clusterFeatures:               ptr.Deref(ytsaurus.Spec.ClusterFeatures, ytv1.ClusterFeatures{}),
+		primaryMaster:                 primaryMaster,
+		secondaryMasters:              secondaryMasters,
+		masterCache:                   masterCache,
+		discoveryInstanceCount:        ytsaurus.Spec.Discovery.InstanceCount,
+		cypressProxiesSpec:            ytsaurus.Spec.CypressProxies,
+		dataNodesInstanceCount:        dataNodesInstanceCount,
+		bundleControllerInstanceCount: ptr.To(bundleControllerInstanceCount),
 	}
 }
 
@@ -1004,6 +1014,14 @@ func (g *NodeGenerator) getTabletNodeConfigImpl(spec *ytv1.TabletNodesSpec) (Tab
 	c, err := getTabletNodeServerCarcass(spec)
 	if err != nil {
 		return c, err
+	}
+	// Suppress "Conflicting profiling tags" alert which occurs when tablet cells
+	// of different bundles share a node. That might happen if there is no bundle
+	// controller.
+	if count := g.bundleControllerInstanceCount; count != nil && *count == 0 {
+		c.CellarNode = &CellarNode{
+			DeduceProfilingTagFromBundleName: ptr.To(false),
+		}
 	}
 	g.fillCommonService(&c.CommonServer, &spec.InstanceSpec)
 	g.fillBusServer(&c.CommonServer, spec.NativeTransport)

--- a/pkg/ytconfig/generator_test.go
+++ b/pkg/ytconfig/generator_test.go
@@ -478,6 +478,43 @@ func TestGetTabletNodeWithoutYtsaurusConfig(t *testing.T) {
 	canonize.Assert(t, cfg)
 }
 
+func TestGetTabletNodeConfigDeduceProfilingTagFromBundleName(t *testing.T) {
+	tabletNodeSpec := getTabletNodeSpec()
+
+	t.Run("with bundle controller", func(t *testing.T) {
+		ytsaurus := withBundleController(getYtsaurus())
+		g := NewGenerator(ytsaurus, testClusterDomain)
+		c, err := g.getTabletNodeConfigImpl(&tabletNodeSpec)
+		require.NoError(t, err)
+		// Bundle controller present: option must not be set.
+		require.Nil(t, c.CellarNode)
+	})
+
+	t.Run("without bundle controller", func(t *testing.T) {
+		ytsaurus := getYtsaurus()
+		ytsaurus.Spec.BundleController = nil
+		g := NewGenerator(ytsaurus, testClusterDomain)
+		c, err := g.getTabletNodeConfigImpl(&tabletNodeSpec)
+		require.NoError(t, err)
+		require.NotNil(t, c.CellarNode)
+		require.NotNil(t, c.CellarNode.DeduceProfilingTagFromBundleName)
+		require.False(t, *c.CellarNode.DeduceProfilingTagFromBundleName)
+	})
+
+	t.Run("zero instance count bundle controller", func(t *testing.T) {
+		ytsaurus := getYtsaurus()
+		ytsaurus.Spec.BundleController = &ytv1.BundleControllerSpec{
+			InstanceSpec: ytv1.InstanceSpec{InstanceCount: 0},
+		}
+		g := NewGenerator(ytsaurus, testClusterDomain)
+		c, err := g.getTabletNodeConfigImpl(&tabletNodeSpec)
+		require.NoError(t, err)
+		require.NotNil(t, c.CellarNode)
+		require.NotNil(t, c.CellarNode.DeduceProfilingTagFromBundleName)
+		require.False(t, *c.CellarNode.DeduceProfilingTagFromBundleName)
+	})
+}
+
 func TestGetOffshoreDataGatewaysWithoutYtsaurusConfig(t *testing.T) {
 	g := NewRemoteNodeGenerator(
 		getRemoteYtsaurus(),

--- a/pkg/ytconfig/node.go
+++ b/pkg/ytconfig/node.go
@@ -297,6 +297,10 @@ type TabletNode struct {
 	VersionedChunkMetaCache Cache `yson:"versioned_chunk_meta_cache"`
 }
 
+type CellarNode struct {
+	DeduceProfilingTagFromBundleName *bool `yson:"deduce_profiling_tag_from_bundle_name,omitempty"`
+}
+
 type NodeServer struct {
 	CommonServer
 	Flavors        []NodeFlavor   `yson:"flavors"`
@@ -323,7 +327,8 @@ type ExecNodeServer struct {
 type TabletNodeServer struct {
 	NodeServer
 	// TabletNode `yson:"tablet_node"`
-	CachingObjectService Cache `yson:"caching_object_service"`
+	CellarNode           *CellarNode `yson:"cellar_node,omitempty"`
+	CachingObjectService Cache       `yson:"caching_object_service"`
 }
 
 func findVolumeMountForPath(locationPath string, spec ytv1.InstanceSpec) *corev1.VolumeMount {


### PR DESCRIPTION
If bundle controller is not present, set
"/cluster_node/deduce_profiling_tag_from_bundle_name" option to the node config.