### PR TITLE
Add master cell role, tag, id labels for stateful-sets and pods

### DIFF
--- a/pkg/components/master.go
+++ b/pkg/components/master.go
@@ -135,6 +135,14 @@ func (m *Master) IsPrimary() bool {
 	return m.labeller.InstanceGroup == ""
 }
 
+func (m *Master) IsMulticell() bool {
+	return !m.IsPrimary() || len(m.secondaryMasters) > 0
+}
+
+func (m *Master) GetRoles() []ytv1.MasterCellRole {
+	return ytv1.GetMasterCellRoles(m.mastersSpec.Roles, m.IsPrimary(), m.IsMulticell())
+}
+
 func (m *Master) IsUnregistered() bool {
 	maintenance := m.ytsaurus.GetResource().Status.UpdateStatus.MasterCellsMaintenance
 	return slices.ContainsFunc(maintenance, func(info ytv1.MasterCellMaintenanceInfo) bool {
@@ -781,9 +789,19 @@ func (m *Master) ServerSync(ctx context.Context, dry bool) (ComponentStatus, err
 func (m *Master) doServerSync(ctx context.Context) error {
 	statefulSet := m.server.buildStatefulSet()
 
+	stsMeta := &statefulSet.ObjectMeta
 	podMeta := &statefulSet.Spec.Template.ObjectMeta
-	metav1.SetMetaDataLabel(podMeta, consts.YTCellTagLabelName, m.labeller.GetCellName(m.mastersSpec.CellTag))
-	metav1.SetMetaDataLabel(podMeta, consts.YTCellIDLabelName, m.cfgen.GetCellID(m.mastersSpec.CellTag))
+	cellTag := m.labeller.GetCellName(m.mastersSpec.CellTag)
+	cellID := m.cfgen.GetCellID(m.mastersSpec.CellTag)
+	metav1.SetMetaDataLabel(stsMeta, consts.YTCellTagLabelName, cellTag)
+	metav1.SetMetaDataLabel(stsMeta, consts.YTCellIDLabelName, cellID)
+	metav1.SetMetaDataLabel(podMeta, consts.YTCellTagLabelName, cellTag)
+	metav1.SetMetaDataLabel(podMeta, consts.YTCellIDLabelName, cellID)
+	for _, role := range m.GetRoles() {
+		roleLabel := m.labeller.GetCellRoleLabelName(role)
+		metav1.SetMetaDataLabel(stsMeta, roleLabel, "")
+		metav1.SetMetaDataLabel(podMeta, roleLabel, "")
+	}
 
 	// Arm restart of masters after cell roles initialization to refresh cached cluster metadata.
 	if m.ytsaurus.IsInitializing() && !m.owner.IsStatusConditionTrue(consts.ConditionMasterCellsInitialized) {

--- a/pkg/consts/labels.go
+++ b/pkg/consts/labels.go
@@ -9,6 +9,8 @@ const (
 	YTCellTagLabelName = "ytsaurus.tech/cell-tag"
 	YTCellIDLabelName  = "ytsaurus.tech/cell-id"
 
+	YTCellRoleLabelPrefix = "cell-role.ytsaurus.tech/"
+
 	YTComponentLabelName = "yt_component"
 	YTMetricsLabelName   = "yt_metrics"
 

--- a/pkg/labeller/labeller.go
+++ b/pkg/labeller/labeller.go
@@ -3,8 +3,11 @@ package labeller
 import (
 	"fmt"
 	"maps"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	ytv1 "github.com/ytsaurus/ytsaurus-k8s-operator/api/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -58,6 +61,10 @@ func (l *Labeller) GetClusterDomain() string {
 func (l *Labeller) GetCellName(cellTag uint16) string {
 	// Decimal like in cypress: "//sys/secondary_masters/{cell-tag}/{address}".
 	return fmt.Sprintf("%d", cellTag)
+}
+
+func (l *Labeller) GetCellRoleLabelName(role ytv1.MasterCellRole) string {
+	return consts.YTCellRoleLabelPrefix + strings.ReplaceAll(string(role), "_", "-")
 }
 
 // getGroupName converts <name> into <name>[-group]

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/Object List.yaml
@@ -152,7 +152,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/Object List.yaml
@@ -189,7 +189,11 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -210,7 +214,11 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
     yt_component: test-ytsaurus-yt-master-2
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-20259-79747361
+    ytsaurus.tech/cell-tag: "2"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-2
   namespace: ytsaurus-components
@@ -231,7 +239,11 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
     yt_component: test-ytsaurus-yt-master-3
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-30259-79747361
+    ytsaurus.tech/cell-tag: "3"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-3
   namespace: ytsaurus-components
@@ -253,6 +265,8 @@
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
     yt_component: test-ytsaurus-yt-master-4
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-40259-79747361
+    ytsaurus.tech/cell-tag: "4"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-4
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/StatefulSet ms-2.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/StatefulSet ms-2.yaml
@@ -8,7 +8,11 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
     yt_component: test-ytsaurus-yt-master-2
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-20259-79747361
+    ytsaurus.tech/cell-tag: "2"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-2
   namespace: ytsaurus-components
@@ -36,6 +40,8 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
         yt_component: test-ytsaurus-yt-master-2
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-20259-79747361
         ytsaurus.tech/cell-tag: "2"

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/StatefulSet ms-3.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/StatefulSet ms-3.yaml
@@ -8,7 +8,11 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
     yt_component: test-ytsaurus-yt-master-3
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-30259-79747361
+    ytsaurus.tech/cell-tag: "3"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-3
   namespace: ytsaurus-components
@@ -36,6 +40,8 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
         yt_component: test-ytsaurus-yt-master-3
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-30259-79747361
         ytsaurus.tech/cell-tag: "3"

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/StatefulSet ms-4.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/StatefulSet ms-4.yaml
@@ -9,6 +9,8 @@ metadata:
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
     yt_component: test-ytsaurus-yt-master-4
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-40259-79747361
+    ytsaurus.tech/cell-tag: "4"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-4
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/StatefulSet ms.yaml
@@ -8,7 +8,11 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +40,8 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/Object List.yaml
@@ -149,7 +149,11 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -170,7 +174,11 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
     yt_component: test-ytsaurus-yt-master-2
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-20259-79747361
+    ytsaurus.tech/cell-tag: "2"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-2
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/StatefulSet ms-2.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/StatefulSet ms-2.yaml
@@ -8,7 +8,11 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
     yt_component: test-ytsaurus-yt-master-2
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-20259-79747361
+    ytsaurus.tech/cell-tag: "2"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-2
   namespace: ytsaurus-components
@@ -36,6 +40,8 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
         yt_component: test-ytsaurus-yt-master-2
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-20259-79747361
         ytsaurus.tech/cell-tag: "2"

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/StatefulSet ms.yaml
@@ -8,7 +8,11 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +40,8 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler Minimal Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/Object List.yaml
@@ -129,7 +129,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler Minimal Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler With CHYT Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/Object List.yaml
@@ -129,7 +129,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler With CHYT Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/Object List.yaml
@@ -170,7 +170,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/Object List.yaml
@@ -170,7 +170,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/Object List.yaml
@@ -170,7 +170,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/Object List.yaml
@@ -170,7 +170,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/Object List.yaml
@@ -170,7 +170,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler With SPYT Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/Object List.yaml
@@ -129,7 +129,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler With SPYT Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"

--- a/test/r8r/canondata/Components reconciler With all components Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Object List.yaml
@@ -427,7 +427,11 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -449,7 +453,11 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
     yt_component: test-ytsaurus-yt-master-2
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-20259-79747361
+    ytsaurus.tech/cell-tag: "2"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-2
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms-2.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms-2.yaml
@@ -9,7 +9,11 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
     yt_component: test-ytsaurus-yt-master-2
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-20259-79747361
+    ytsaurus.tech/cell-tag: "2"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms-2
   namespace: ytsaurus-components
@@ -39,6 +43,8 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
         global-pod-label: "true"
         yt_component: test-ytsaurus-yt-master-2
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-20259-79747361

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
@@ -9,7 +9,11 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -40,6 +44,8 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         global-pod-label: "true"
         instance-pod-label: "true"
         yt_component: test-ytsaurus-yt-master

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/Object List.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/Object List.yaml
@@ -170,7 +170,12 @@
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/StatefulSet ms.yaml
@@ -8,7 +8,12 @@ metadata:
     app.kubernetes.io/managed-by: ytsaurus-k8s-operator
     app.kubernetes.io/name: yt-master
     app.kubernetes.io/part-of: yt-test-ytsaurus
+    cell-role.ytsaurus.tech/chunk-host: ""
+    cell-role.ytsaurus.tech/cypress-node-host: ""
+    cell-role.ytsaurus.tech/transaction-coordinator: ""
     yt_component: test-ytsaurus-yt-master
+    ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
+    ytsaurus.tech/cell-tag: "1"
     ytsaurus.tech/cluster-name: test-ytsaurus
   name: ms
   namespace: ytsaurus-components
@@ -36,6 +41,9 @@ spec:
         app.kubernetes.io/managed-by: ytsaurus-k8s-operator
         app.kubernetes.io/name: yt-master
         app.kubernetes.io/part-of: yt-test-ytsaurus
+        cell-role.ytsaurus.tech/chunk-host: ""
+        cell-role.ytsaurus.tech/cypress-node-host: ""
+        cell-role.ytsaurus.tech/transaction-coordinator: ""
         yt_component: test-ytsaurus-yt-master
         ytsaurus.tech/cell-id: 65726e65-ad6b7562-10259-79747361
         ytsaurus.tech/cell-tag: "1"


### PR DESCRIPTION
Lebels:

ytsaurus.tech/cell-id
ytsaurus.tech/cell-tag
cell-role.ytsaurus.tech/chunk-host
cell-role.ytsaurus.tech/cypress-node-host
cell-role.ytsaurus.tech/transaction-coordinator

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
