### PR TITLE
Disable stockpile by default

### DIFF
--- a/pkg/ytconfig/canondata/TestGetBundleControllerConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetBundleControllerConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetControllerAgentsConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetCypressProxiesConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetCypressProxiesConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-trash-ttl/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-trash-ttl/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-watermark/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-watermark/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/without-trash-ttl/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/without-trash-ttl/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfig/with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfig/with-job-resources/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfig/without-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfig/without-job-resources/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigJobProxyModePerJobDirectory/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigJobProxyModePerJobDirectory/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigJobProxyModePerJobDirectoryLegacy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigJobProxyModePerJobDirectoryLegacy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigJobProxyModeSimple/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigJobProxyModeSimple/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-with-job-resources/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-without-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-containers-without-job-resources/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-crio-with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/isolated-crio-with-job-resources/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-with-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-with-job-resources/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-without-job-resources/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeConfigWithCri/single-container-without-job-resources/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetExecNodeWithoutYtsaurusConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyConfigDisableCreateOauthUser/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyConfigDisableCreateOauthUser/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyConfigEnableCreateOauthUser/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyConfigEnableCreateOauthUser/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyConfigWithCustomPorts/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyConfigWithCustomPorts/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyWithChytCustomSpecServerNoTls/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyWithChytCustomSpecServerNoTls/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyWithChytServer/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyWithChytServer/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetHTTPProxyWithChytServerNoTls/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetHTTPProxyWithChytServerNoTls/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetMasterCachesWithFixedHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterCachesWithFixedHostsConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetMasterWithFixedHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterWithFixedHostsConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetMasterWithMonitoringPortConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetMasterWithMonitoringPortConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetOffshoreDataGatewaysWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetOffshoreDataGatewaysWithoutYtsaurusConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetRPCProxyWithoutOauthConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetSchedulerWithFixedMasterHostsConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetSchedulerWithFixedMasterHostsConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetSchedulerWithoutTabletNodes/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetSchedulerWithoutTabletNodes/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetTCPProxyConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTCPProxyConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetTabletBalancerConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTabletBalancerConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetTabletNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetTabletNodeWithoutYtsaurusConfig/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%true;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/BundleController/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/BundleController/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/ControllerAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/ControllerAgent/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/DataNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/DataNode/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/Discovery/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/Discovery/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/ExecNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/ExecNode/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/HttpProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/HttpProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/KafkaProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/KafkaProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/Master/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/Master/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/MasterCache/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/MasterCache/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/QueryTracker/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/QueryTracker/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/QueueAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/QueueAgent/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/RpcProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/RpcProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/Scheduler/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/Scheduler/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/TabletBalancer/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/TabletBalancer/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/TabletNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/TabletNode/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/TcpProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/TcpProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/YqlAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/YqlAgent/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/BundleController/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/BundleController/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/ControllerAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/ControllerAgent/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/DataNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/DataNode/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/Discovery/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/Discovery/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/ExecNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/ExecNode/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/HttpProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/HttpProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/KafkaProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/KafkaProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/Master/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/Master/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/MasterCache/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/MasterCache/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/QueryTracker/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/QueryTracker/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/QueueAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/QueueAgent/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/RpcProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/RpcProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/Scheduler/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/Scheduler/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/TabletBalancer/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/TabletBalancer/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/TabletNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/TabletNode/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/TcpProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/TcpProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/YqlAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/YqlAgent/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/BundleController/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/BundleController/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ControllerAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ControllerAgent/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/DataNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/DataNode/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Discovery/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Discovery/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ExecNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/ExecNode/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/HttpProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/HttpProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/KafkaProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/KafkaProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Master/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Master/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/MasterCache/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/MasterCache/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/QueryTracker/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/QueryTracker/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/QueueAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/QueueAgent/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/RpcProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/RpcProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Scheduler/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/Scheduler/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TabletBalancer/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TabletBalancer/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TabletNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TabletNode/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TcpProxy/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/TcpProxy/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/YqlAgent/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/YqlAgent/test.canondata
@@ -4,6 +4,9 @@
         "enable_ipv6"=%false;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/canondata/TestResolverOptionsKeepSocketAndForceTCP/test.canondata
+++ b/pkg/ytconfig/canondata/TestResolverOptionsKeepSocketAndForceTCP/test.canondata
@@ -6,6 +6,9 @@
         "force_tcp"=%true;
         retries=1000;
     };
+    stockpile={
+        "thread_count"=0;
+    };
     "solomon_exporter"={
         host="{POD_SHORT_HOSTNAME}";
         "instance_tags"={

--- a/pkg/ytconfig/common.go
+++ b/pkg/ytconfig/common.go
@@ -103,6 +103,10 @@ type AddressResolver struct {
 	LocalhostNameOverride *string `yson:"localhost_name_override,omitempty"`
 }
 
+type Stockpile struct {
+	ThreadCount *int `yson:"thread_count,omitempty"`
+}
+
 type StrawberryControllerFamiliesConfig struct {
 	ControllerFamilies []string `yson:"controller_families,omitempty"`
 	DefaultRouteFamily string   `yson:"default_route_family,omitempty"`
@@ -167,6 +171,7 @@ type BusServer struct {
 // BasicServer is used as a basic config for basic components, such as clocks or discovery.
 type BasicServer struct {
 	AddressResolver AddressResolver `yson:"address_resolver"`
+	Stockpile       *Stockpile      `yson:"stockpile,omitempty"`
 	SolomonExporter SolomonExporter `yson:"solomon_exporter"`
 	Logging         Logging         `yson:"logging"`
 	MonitoringPort  int32           `yson:"monitoring_port"`

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -479,7 +479,7 @@ func (g *NodeGenerator) fillCommonService(
 	s *ytv1.InstanceSpec,
 	component consts.ComponentType,
 ) {
-	// ToDo(psushin): enable porto resource tracker?
+	c.Stockpile = &Stockpile{ThreadCount: ptr.To(0)} // This is default since 25.3
 	g.fillAddressResolver(&c.AddressResolver)
 	g.fillSolomonExporter(&c.SolomonExporter, s.MetricExporter)
 	keyring := getMountKeyring(g.commonSpec, s.NativeTransport)

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-2-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-2-config.yaml
@@ -86,6 +86,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-3-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-3-config.yaml
@@ -86,6 +86,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-4-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-4-config.yaml
@@ -86,6 +86,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-config.yaml
@@ -86,6 +86,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-2-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-2-config.yaml
@@ -62,6 +62,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-config.yaml
@@ -62,6 +62,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Remote Data nodes Test/ConfigMap yt-data-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler Remote Data nodes Test/ConfigMap yt-data-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Remote Exec nodes Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler Remote Exec nodes Test/ConfigMap yt-exec-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Remote Offshore data nodes Test/ConfigMap yt-offshore-data-gateway-config.yaml
+++ b/test/r8r/canondata/Components reconciler Remote Offshore data nodes Test/ConfigMap yt-offshore-data-gateway-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler Remote Tablet nodes Test/ConfigMap yt-tablet-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler Remote Tablet nodes Test/ConfigMap yt-tablet-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-exec-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-exec-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-exec-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-exec-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-exec-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-controller-agent-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-controller-agent-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-data-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-data-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-exec-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-2-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-2-config.yaml
@@ -78,6 +78,9 @@ data:
             retries=1000;
             "localhost_name_override"="{K8S_POD_NAME}.masters-2.ytsaurus-components.svc.cluster.local";
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-cache-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-cache-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-config.yaml
@@ -77,6 +77,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-rpc-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-rpc-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-scheduler-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-scheduler-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-yql-agent-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-yql-agent-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-discovery-config.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-discovery-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-exec-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-exec-node-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-http-proxy-config.yaml
@@ -6,6 +6,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-master-config.yaml
@@ -48,6 +48,9 @@ data:
             "enable_ipv6"=%false;
             retries=1000;
         };
+        stockpile={
+            "thread_count"=0;
+        };
         "solomon_exporter"={
             host="{POD_SHORT_HOSTNAME}";
             "instance_tags"={


### PR DESCRIPTION
Stop flood in debug log.

It is not supported in mainline linux and off by default since 25.3

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
