### PR TITLE
Cleanup rolling update calculations

### DIFF
--- a/pkg/components/exec_node.go
+++ b/pkg/components/exec_node.go
@@ -133,13 +133,16 @@ func (n *ExecNode) drainExecNodeForRollingUpdate(ctx context.Context) ComponentS
 		return ComponentStatusBlocked("YT client is not available")
 	}
 
-	sts, ok := n.server.getRollingUpdateStatus(ctx)
-	if !ok || sts.partition == nil || *sts.partition == 0 {
+	roll, err := n.server.getRollingUpdateStatus(ctx)
+	if err != nil {
+		return ComponentStatusBlocked("Error: %v", err)
+	}
+	if roll == nil || roll.partition == 0 {
 		return ComponentStatusReady()
 	}
 
-	partition := int(*sts.partition)
-	totalCount := int(sts.totalCount)
+	partition := int(roll.partition)
+	totalCount := int(roll.totalCount)
 
 	// Drain the pod about to be updated (at partition-1).
 	if s := n.drainExecNode(ctx, ytClient, partition-1); s.SyncStatus != SyncStatusReady {

--- a/pkg/components/helpers.go
+++ b/pkg/components/helpers.go
@@ -429,61 +429,43 @@ func handleRollingUpdatingClusterState(
 		return ptr.To(ComponentStatusUpdateStep("rolling update")), nil
 	}
 
-	sts, ok := server.getRollingUpdateStatus(ctx)
-	if !ok {
-		return ptr.To(ComponentStatusUpdateStep("rolling update")), nil
+	roll, err := server.getRollingUpdateStatus(ctx)
+	if err != nil || roll == nil {
+		return ptr.To(ComponentStatusUpdateStep("rolling update is not ready")), err
 	}
-
-	totalCount := sts.totalCount
 
 	// Init guard: the StatefulSet still differs from desired spec (needUpdate=true),
 	// so this is the start of a new rolling cycle and we must initialize
 	// RollingUpdate strategy with a fresh partition/maxUnavailable.
 	if status := server.needUpdate(); status.IsNeedUpdate() {
-		server.setUpdateStrategy(appsv1.RollingUpdateStatefulSetStrategyType, totalCount-1, maxUnavailable)
+		server.setUpdateStrategy(appsv1.RollingUpdateStatefulSetStrategyType, roll.totalCount, maxUnavailable)
 		if err := server.Sync(ctx); err != nil {
 			return ptr.To(ComponentStatusBlocked("failed to initialize rolling update for %s", cmp.GetFullName())), err
 		}
-		return ptr.To(ComponentStatusUpdateStep("rolling update")), nil
+		return ptr.To(ComponentStatusUpdateStep("rolling started")), nil
 	}
 
-	partition := *sts.partition
-
-	// Completion: all pods are exposed and on the new revision.
-	if partition == 0 && sts.updatedReplicas == totalCount {
+	if roll.IsFinished() {
 		setPodsUpdatedCondition(ctx, ytsaurus, cmp)
 		return nil, nil
 	}
 
-	// Budget calculation.
-	// inProgress: pods committed to update (below partition) but not yet on the new revision.
-	// This covers the timing window where partition was lowered but pods haven't restarted yet.
-	inProgress := max(int32(0), (totalCount-partition)-sts.updatedReplicas)
-	// effective: take the larger of actual unavailability and in-progress count to avoid
-	// double-counting pods that are both in-progress and already unavailable.
-	effective := max(totalCount-sts.availableReplicas, inProgress)
-	budget := maxUnavailable - effective
-
-	if partition == 0 {
-		return ptr.To(ComponentStatusUpdateStep("rolling update")), nil
-	}
-
-	if budget <= 0 {
-		setRollingBudgetExhaustedCondition(ctx, ytsaurus, cmp, maxUnavailable, effective, partition)
-		return ptr.To(ComponentStatusUpdateStep("rolling update")), nil
-	}
-
-	if ytsaurus.ShouldRunPreChecks(cmp.GetType(), cmp.GetFullName()) {
-		if status, err := runPrechecks(ctx, ytsaurus, cmp); status != nil {
-			return status, err
+	if wasted := roll.UnavailableOrInProgressReplicas(); wasted >= maxUnavailable {
+		setRollingBudgetExhaustedCondition(ctx, ytsaurus, cmp, maxUnavailable, wasted, roll.partition)
+	} else if roll.partition != 0 {
+		if ytsaurus.ShouldRunPreChecks(cmp.GetType(), cmp.GetFullName()) {
+			if status, err := runPrechecks(ctx, ytsaurus, cmp); status != nil {
+				return status, err
+			}
+		}
+		// Advance rolling process one by one. Slow and steady.
+		server.setUpdateStrategy(appsv1.RollingUpdateStatefulSetStrategyType, roll.partition-1, maxUnavailable)
+		if err := server.Sync(ctx); err != nil {
+			return ptr.To(ComponentStatusBlocked("failed to advance rolling update partition for %s", cmp.GetFullName())), err
 		}
 	}
 
-	server.setUpdateStrategy(appsv1.RollingUpdateStatefulSetStrategyType, partition-1, maxUnavailable)
-	if err := server.Sync(ctx); err != nil {
-		return ptr.To(ComponentStatusBlocked("failed to advance rolling update partition for %s", cmp.GetFullName())), err
-	}
-	return ptr.To(ComponentStatusUpdateStep("rolling update")), nil
+	return ptr.To(ComponentStatusUpdating("Rolling update: %v of %v pods", roll.updatedReplicas, roll.totalCount)), nil
 }
 
 func setRollingBudgetExhaustedCondition(

--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -34,7 +34,7 @@ type server interface {
 	podsManager
 
 	setUpdateStrategy(strategy appsv1.StatefulSetUpdateStrategyType, partition, maxUnavailable int32)
-	getRollingUpdateStatus(ctx context.Context) (*stsRollingStatus, bool)
+	getRollingUpdateStatus(ctx context.Context) (*stsRollingStatus, error)
 
 	needUpdate() ComponentStatus
 	needSync(updating bool) bool
@@ -484,8 +484,8 @@ func evaluateOnDeleteCompletion(pods []corev1.Pod, updateRevision string, replic
 func (s *serverImpl) arePodsUpdatedToNewRevision(ctx context.Context) bool {
 	logger := log.FromContext(ctx)
 
-	sts, ok := s.fetchAndValidateStatefulSet(ctx)
-	if !ok {
+	sts, err := s.fetchAndValidateStatefulSet(ctx)
+	if err != nil || sts == nil {
 		return false
 	}
 
@@ -762,7 +762,7 @@ func (s *serverImpl) setUpdateStrategy(strategy appsv1.StatefulSetUpdateStrategy
 }
 
 type stsRollingStatus struct {
-	partition         *int32
+	partition         int32
 	availableReplicas int32
 	updatedReplicas   int32
 	totalCount        int32
@@ -770,50 +770,64 @@ type stsRollingStatus struct {
 	currentRevision   string
 }
 
-func (s *serverImpl) getRollingUpdateStatus(ctx context.Context) (*stsRollingStatus, bool) {
-	sts, ok := s.fetchAndValidateStatefulSet(ctx)
-	if !ok {
-		return nil, false
-	}
+// IsFinished is true when all pods are exposed and on the new revision.
+func (s stsRollingStatus) IsFinished() bool {
+	return s.partition == 0 && s.updatedReplicas == s.totalCount
+}
 
-	var partition *int32
+func (s stsRollingStatus) UnavailableReplicas() int32 {
+	return max(int32(0), s.totalCount-s.availableReplicas)
+}
+
+// InProgressReplicas counts pods committed to update (above partition) but not yet on the new revision.
+// This covers the timing window where partition was lowered but pods haven't restarted yet.
+func (s stsRollingStatus) InProgressReplicas() int32 {
+	return max(int32(0), s.totalCount-s.partition-s.updatedReplicas)
+}
+
+func (s stsRollingStatus) UnavailableOrInProgressReplicas() int32 {
+	// Take the larger of actual unavailability and in-progress count to avoid
+	// double-counting pods that are both in-progress and already unavailable.
+	return max(s.UnavailableReplicas(), s.InProgressReplicas())
+}
+
+func (s *serverImpl) getRollingUpdateStatus(ctx context.Context) (*stsRollingStatus, error) {
+	sts, err := s.fetchAndValidateStatefulSet(ctx)
+	if err != nil || sts == nil {
+		return nil, err
+	}
+	var partition int32
 	if sts.Spec.UpdateStrategy.RollingUpdate != nil {
-		partition = sts.Spec.UpdateStrategy.RollingUpdate.Partition
+		partition = ptr.Deref(sts.Spec.UpdateStrategy.RollingUpdate.Partition, 0)
 	}
-
-	totalCount := int32(0)
-	if sts.Spec.Replicas != nil {
-		totalCount = *sts.Spec.Replicas
-	}
-
 	return &stsRollingStatus{
+		totalCount:        ptr.Deref(sts.Spec.Replicas, 1),
 		partition:         partition,
 		availableReplicas: sts.Status.AvailableReplicas,
 		updatedReplicas:   sts.Status.UpdatedReplicas,
-		totalCount:        totalCount,
 		updateRevision:    sts.Status.UpdateRevision,
 		currentRevision:   sts.Status.CurrentRevision,
-	}, true
+	}, nil
 }
 
 func (s *serverImpl) addMonitoringPort(port corev1.ServicePort) {
 	s.monitoringService.AddPort(port)
 }
 
-func (s *serverImpl) fetchAndValidateStatefulSet(ctx context.Context) (*appsv1.StatefulSet, bool) {
+func (s *serverImpl) fetchAndValidateStatefulSet(ctx context.Context) (*appsv1.StatefulSet, error) {
 	logger := log.FromContext(ctx)
 	if !resources.Exists(s.statefulSet) {
-		return nil, false
+		return nil, nil
 	}
 
 	if err := s.statefulSet.Fetch(ctx); err != nil {
 		logger.Error(err, "Failed to fetch StatefulSet status", "component", s.labeller.GetFullComponentName())
-		return nil, false
+		return nil, err
 	}
 
 	sts := s.statefulSet.OldObject()
 	if sts.Status.UpdateRevision == "" {
-		return nil, false
+		return nil, nil
 	}
 
 	// for race condition case when new revision is created but status not updated yet
@@ -822,7 +836,8 @@ func (s *serverImpl) fetchAndValidateStatefulSet(ctx context.Context) (*appsv1.S
 			"component", s.labeller.GetFullComponentName(),
 			"generation", sts.Generation,
 			"observedGeneration", sts.Status.ObservedGeneration)
-		return nil, false
+		return nil, nil
 	}
-	return sts, true
+
+	return sts, nil
 }

--- a/pkg/components/suite_test.go
+++ b/pkg/components/suite_test.go
@@ -182,8 +182,8 @@ func (fs *FakeServer) listPods(ctx context.Context) ([]corev1.Pod, error) {
 	return nil, nil
 }
 
-func (fs *FakeServer) getRollingUpdateStatus(ctx context.Context) (*stsRollingStatus, bool) {
-	return nil, false
+func (fs *FakeServer) getRollingUpdateStatus(ctx context.Context) (*stsRollingStatus, error) {
+	return nil, nil
 }
 
 func (fs *FakeServer) Sync(ctx context.Context) error {


### PR DESCRIPTION
Move progress estimation into methods.
Pass errors to the caller.
Report progress into component status.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
