### PR TITLE
Support yson structured logs and multi-category filter in timbertruck

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -335,9 +335,11 @@ type TextLoggerSpec struct {
 
 type StructuredLoggerSpec struct {
 	BaseLoggerSpec `json:",inline"`
-	Category       string `json:"category,omitempty"`
-	// Additional include/exclude category filter applied on top of category.
-	// Type must be set.
+	// Single category to log. Exactly one of category and categoriesFilter must be set.
+	//+optional
+	Category string `json:"category,omitempty"`
+	// Category filter for logs spanning several categories, as for text loggers.
+	// Type must be set. Exactly one of category and categoriesFilter must be set.
 	//+optional
 	CategoriesFilter *CategoriesFilter `json:"categoriesFilter,omitempty"`
 	// EnableDelivery turns on timbertruck delivery of this structured log to the cluster log storage.

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -337,8 +337,7 @@ type StructuredLoggerSpec struct {
 	BaseLoggerSpec `json:",inline"`
 	Category       string `json:"category,omitempty"`
 	// Additional include/exclude category filter applied on top of category.
-	// Lets one logger span several categories, e.g. the scheduler event log is written
-	// under both SchedulerStructuredLog and SchedulerEventLog. Type must be set.
+	// Type must be set.
 	//+optional
 	CategoriesFilter *CategoriesFilter `json:"categoriesFilter,omitempty"`
 	// EnableDelivery turns on timbertruck delivery of this structured log to the cluster log storage.

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -335,11 +335,11 @@ type TextLoggerSpec struct {
 
 type StructuredLoggerSpec struct {
 	BaseLoggerSpec `json:",inline"`
-	// Single category to log. Exactly one of category and categoriesFilter must be set.
+	// Exactly one of category and categoriesFilter must be set.
 	//+optional
 	Category string `json:"category,omitempty"`
-	// Category filter for logs spanning several categories, as for text loggers.
-	// Type must be set. Exactly one of category and categoriesFilter must be set.
+	// Filter for logs spanning several categories. Type must be set.
+	// Exactly one of category and categoriesFilter must be set.
 	//+optional
 	CategoriesFilter *CategoriesFilter `json:"categoriesFilter,omitempty"`
 	// EnableDelivery turns on timbertruck delivery of this structured log to the cluster log storage.

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -337,7 +337,7 @@ type StructuredLoggerSpec struct {
 	BaseLoggerSpec `json:",inline"`
 	// Exactly one of category and categoriesFilter must be set.
 	//+optional
-	Category string `json:"category,omitempty"`
+	Category *string `json:"category,omitempty"`
 	// Filter for logs spanning several categories. Type must be set.
 	// Exactly one of category and categoriesFilter must be set.
 	//+optional

--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -336,6 +336,11 @@ type TextLoggerSpec struct {
 type StructuredLoggerSpec struct {
 	BaseLoggerSpec `json:",inline"`
 	Category       string `json:"category,omitempty"`
+	// Additional include/exclude category filter applied on top of category.
+	// Lets one logger span several categories, e.g. the scheduler event log is written
+	// under both SchedulerStructuredLog and SchedulerEventLog. Type must be set.
+	//+optional
+	CategoriesFilter *CategoriesFilter `json:"categoriesFilter,omitempty"`
 	// EnableDelivery turns on timbertruck delivery of this structured log to the cluster log storage.
 	// Requires a timbertruck image to be configured (spec.timbertruck.image or, for masters, primaryMasters.timbertruck.image).
 	//+optional

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -2381,6 +2381,11 @@ func (in *StrawberryControllerSpec) DeepCopy() *StrawberryControllerSpec {
 func (in *StructuredLoggerSpec) DeepCopyInto(out *StructuredLoggerSpec) {
 	*out = *in
 	in.BaseLoggerSpec.DeepCopyInto(&out.BaseLoggerSpec)
+	if in.CategoriesFilter != nil {
+		in, out := &in.CategoriesFilter, &out.CategoriesFilter
+		*out = new(CategoriesFilter)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EnableDelivery != nil {
 		in, out := &in.EnableDelivery, &out.EnableDelivery
 		*out = new(bool)

--- a/api/v1/zz_generated.deepcopy.go
+++ b/api/v1/zz_generated.deepcopy.go
@@ -2381,6 +2381,11 @@ func (in *StrawberryControllerSpec) DeepCopy() *StrawberryControllerSpec {
 func (in *StructuredLoggerSpec) DeepCopyInto(out *StructuredLoggerSpec) {
 	*out = *in
 	in.BaseLoggerSpec.DeepCopyInto(&out.BaseLoggerSpec)
+	if in.Category != nil {
+		in, out := &in.Category, &out.Category
+		*out = new(string)
+		**out = **in
+	}
 	if in.CategoriesFilter != nil {
 		in, out := &in.CategoriesFilter, &out.CategoriesFilter
 		*out = new(CategoriesFilter)

--- a/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -1226,8 +1226,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Additional include/exclude category filter applied
-                        on top of category.
+                      description: Category filter for logs spanning several categories,
+                        as for text loggers.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1243,6 +1243,7 @@ spec:
                           type: array
                       type: object
                     category:
+                      description: Single category to log.
                       type: string
                     compression:
                       default: none

--- a/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -1225,6 +1225,23 @@ spec:
               structuredLoggers:
                 items:
                   properties:
+                    categoriesFilter:
+                      description: Additional include/exclude category filter applied
+                        on top of category.
+                      properties:
+                        type:
+                          description: CategoriesFilterType string describes types
+                            of possible log CategoriesFilter.
+                          enum:
+                          - exclude
+                          - include
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
                     category:
                       type: string
                     compression:

--- a/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -1226,8 +1226,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Category filter for logs spanning several categories,
-                        as for text loggers.
+                      description: Filter for logs spanning several categories. Type
+                        must be set.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1243,7 +1243,8 @@ spec:
                           type: array
                       type: object
                     category:
-                      description: Single category to log.
+                      description: Exactly one of category and categoriesFilter must
+                        be set.
                       type: string
                     compression:
                       default: none

--- a/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -1231,8 +1231,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Category filter for logs spanning several categories,
-                        as for text loggers.
+                      description: Filter for logs spanning several categories. Type
+                        must be set.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1248,7 +1248,8 @@ spec:
                           type: array
                       type: object
                     category:
-                      description: Single category to log.
+                      description: Exactly one of category and categoriesFilter must
+                        be set.
                       type: string
                     compression:
                       default: none

--- a/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -1231,8 +1231,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Additional include/exclude category filter applied
-                        on top of category.
+                      description: Category filter for logs spanning several categories,
+                        as for text loggers.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1248,6 +1248,7 @@ spec:
                           type: array
                       type: object
                     category:
+                      description: Single category to log.
                       type: string
                     compression:
                       default: none

--- a/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -1230,6 +1230,23 @@ spec:
               structuredLoggers:
                 items:
                   properties:
+                    categoriesFilter:
+                      description: Additional include/exclude category filter applied
+                        on top of category.
+                      properties:
+                        type:
+                          description: CategoriesFilterType string describes types
+                            of possible log CategoriesFilter.
+                          enum:
+                          - exclude
+                          - include
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
                     category:
                       type: string
                     compression:

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -1495,8 +1495,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Additional include/exclude category filter applied
-                        on top of category.
+                      description: Category filter for logs spanning several categories,
+                        as for text loggers.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1512,6 +1512,7 @@ spec:
                           type: array
                       type: object
                     category:
+                      description: Single category to log.
                       type: string
                     compression:
                       default: none

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -1495,8 +1495,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Category filter for logs spanning several categories,
-                        as for text loggers.
+                      description: Filter for logs spanning several categories. Type
+                        must be set.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1512,7 +1512,8 @@ spec:
                           type: array
                       type: object
                     category:
-                      description: Single category to log.
+                      description: Exactly one of category and categoriesFilter must
+                        be set.
                       type: string
                     compression:
                       default: none

--- a/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -1494,6 +1494,23 @@ spec:
               structuredLoggers:
                 items:
                   properties:
+                    categoriesFilter:
+                      description: Additional include/exclude category filter applied
+                        on top of category.
+                      properties:
+                        type:
+                          description: CategoriesFilterType string describes types
+                            of possible log CategoriesFilter.
+                          enum:
+                          - exclude
+                          - include
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
                     category:
                       type: string
                     compression:

--- a/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -1231,8 +1231,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Category filter for logs spanning several categories,
-                        as for text loggers.
+                      description: Filter for logs spanning several categories. Type
+                        must be set.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1248,7 +1248,8 @@ spec:
                           type: array
                       type: object
                     category:
-                      description: Single category to log.
+                      description: Exactly one of category and categoriesFilter must
+                        be set.
                       type: string
                     compression:
                       default: none

--- a/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -1231,8 +1231,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Additional include/exclude category filter applied
-                        on top of category.
+                      description: Category filter for logs spanning several categories,
+                        as for text loggers.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1248,6 +1248,7 @@ spec:
                           type: array
                       type: object
                     category:
+                      description: Single category to log.
                       type: string
                     compression:
                       default: none

--- a/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -1230,6 +1230,23 @@ spec:
               structuredLoggers:
                 items:
                   properties:
+                    categoriesFilter:
+                      description: Additional include/exclude category filter applied
+                        on top of category.
+                      properties:
+                        type:
+                          description: CategoriesFilterType string describes types
+                            of possible log CategoriesFilter.
+                          enum:
+                          - exclude
+                          - include
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
                     category:
                       type: string
                     compression:

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -1121,6 +1121,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -3125,6 +3142,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -5005,6 +5039,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -6898,6 +6949,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -8784,6 +8852,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -10984,6 +11069,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -12930,6 +13032,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -14865,6 +14984,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -16762,6 +16898,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -18764,6 +18917,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -20651,6 +20821,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -22527,6 +22714,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -24428,6 +24632,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -26346,6 +26567,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -28268,6 +28506,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -30330,6 +30585,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -32223,6 +32495,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -34135,6 +34424,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -36498,6 +36804,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -1122,8 +1122,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -1139,6 +1139,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -3143,8 +3144,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -3160,6 +3161,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -5040,8 +5042,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -5057,6 +5059,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -6950,8 +6953,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -6967,6 +6970,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -8853,8 +8857,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -8870,6 +8874,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -11070,8 +11075,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -11087,6 +11092,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -13033,8 +13039,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -13050,6 +13056,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -14985,8 +14992,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -15002,6 +15009,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -16899,8 +16907,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -16916,6 +16924,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -18918,8 +18927,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -18935,6 +18944,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -20822,8 +20832,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -20839,6 +20849,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -22715,8 +22726,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -22732,6 +22743,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -24633,8 +24645,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -24650,6 +24662,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -26568,8 +26581,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -26585,6 +26598,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -28507,8 +28521,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -28524,6 +28538,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -30586,8 +30601,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -30603,6 +30618,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -32496,8 +32512,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -32513,6 +32529,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -34425,8 +34442,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -34442,6 +34459,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -36805,8 +36823,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -36822,6 +36840,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -1122,8 +1122,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -1139,7 +1139,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -3144,8 +3145,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -3161,7 +3162,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -5042,8 +5044,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -5059,7 +5061,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -6953,8 +6956,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -6970,7 +6973,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -8857,8 +8861,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -8874,7 +8878,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -11075,8 +11080,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -11092,7 +11097,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -13039,8 +13045,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -13056,7 +13062,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -14992,8 +14999,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -15009,7 +15016,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -16907,8 +16915,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -16924,7 +16932,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -18927,8 +18936,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -18944,7 +18953,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -20832,8 +20842,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -20849,7 +20859,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -22726,8 +22737,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -22743,7 +22754,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -24645,8 +24657,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -24662,7 +24674,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -26581,8 +26594,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -26598,7 +26611,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -28521,8 +28535,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -28538,7 +28552,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -30601,8 +30616,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -30618,7 +30633,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -32512,8 +32528,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -32529,7 +32545,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -34442,8 +34459,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -34459,7 +34476,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -36823,8 +36841,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -36840,7 +36858,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none

--- a/config/crd/schema/cluster.ytsaurus.tech_offshoredatagateways_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_offshoredatagateways_v1.json
@@ -1434,6 +1434,27 @@
           "items": {
             "type": "object",
             "properties": {
+              "categoriesFilter": {
+                "description": "Additional include/exclude category filter applied on top of category.",
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                    "type": "string",
+                    "enum": [
+                      "exclude",
+                      "include"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
               "category": {
                 "type": "string"
               },

--- a/config/crd/schema/cluster.ytsaurus.tech_offshoredatagateways_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_offshoredatagateways_v1.json
@@ -1435,7 +1435,7 @@
             "type": "object",
             "properties": {
               "categoriesFilter": {
-                "description": "Category filter for logs spanning several categories, as for text loggers.",
+                "description": "Filter for logs spanning several categories. Type must be set.",
                 "type": "object",
                 "properties": {
                   "type": {
@@ -1456,7 +1456,7 @@
                 }
               },
               "category": {
-                "description": "Single category to log.",
+                "description": "Exactly one of category and categoriesFilter must be set.",
                 "type": "string"
               },
               "compression": {

--- a/config/crd/schema/cluster.ytsaurus.tech_offshoredatagateways_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_offshoredatagateways_v1.json
@@ -1435,7 +1435,7 @@
             "type": "object",
             "properties": {
               "categoriesFilter": {
-                "description": "Additional include/exclude category filter applied on top of category.",
+                "description": "Category filter for logs spanning several categories, as for text loggers.",
                 "type": "object",
                 "properties": {
                   "type": {
@@ -1456,6 +1456,7 @@
                 }
               },
               "category": {
+                "description": "Single category to log.",
                 "type": "string"
               },
               "compression": {

--- a/config/crd/schema/cluster.ytsaurus.tech_remotedatanodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remotedatanodes_v1.json
@@ -1443,6 +1443,27 @@
           "items": {
             "type": "object",
             "properties": {
+              "categoriesFilter": {
+                "description": "Additional include/exclude category filter applied on top of category.",
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                    "type": "string",
+                    "enum": [
+                      "exclude",
+                      "include"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
               "category": {
                 "type": "string"
               },

--- a/config/crd/schema/cluster.ytsaurus.tech_remotedatanodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remotedatanodes_v1.json
@@ -1444,7 +1444,7 @@
             "type": "object",
             "properties": {
               "categoriesFilter": {
-                "description": "Additional include/exclude category filter applied on top of category.",
+                "description": "Category filter for logs spanning several categories, as for text loggers.",
                 "type": "object",
                 "properties": {
                   "type": {
@@ -1465,6 +1465,7 @@
                 }
               },
               "category": {
+                "description": "Single category to log.",
                 "type": "string"
               },
               "compression": {

--- a/config/crd/schema/cluster.ytsaurus.tech_remotedatanodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remotedatanodes_v1.json
@@ -1444,7 +1444,7 @@
             "type": "object",
             "properties": {
               "categoriesFilter": {
-                "description": "Category filter for logs spanning several categories, as for text loggers.",
+                "description": "Filter for logs spanning several categories. Type must be set.",
                 "type": "object",
                 "properties": {
                   "type": {
@@ -1465,7 +1465,7 @@
                 }
               },
               "category": {
-                "description": "Single category to log.",
+                "description": "Exactly one of category and categoriesFilter must be set.",
                 "type": "string"
               },
               "compression": {

--- a/config/crd/schema/cluster.ytsaurus.tech_remoteexecnodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remoteexecnodes_v1.json
@@ -1791,7 +1791,7 @@
             "type": "object",
             "properties": {
               "categoriesFilter": {
-                "description": "Category filter for logs spanning several categories, as for text loggers.",
+                "description": "Filter for logs spanning several categories. Type must be set.",
                 "type": "object",
                 "properties": {
                   "type": {
@@ -1812,7 +1812,7 @@
                 }
               },
               "category": {
-                "description": "Single category to log.",
+                "description": "Exactly one of category and categoriesFilter must be set.",
                 "type": "string"
               },
               "compression": {

--- a/config/crd/schema/cluster.ytsaurus.tech_remoteexecnodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remoteexecnodes_v1.json
@@ -1791,7 +1791,7 @@
             "type": "object",
             "properties": {
               "categoriesFilter": {
-                "description": "Additional include/exclude category filter applied on top of category.",
+                "description": "Category filter for logs spanning several categories, as for text loggers.",
                 "type": "object",
                 "properties": {
                   "type": {
@@ -1812,6 +1812,7 @@
                 }
               },
               "category": {
+                "description": "Single category to log.",
                 "type": "string"
               },
               "compression": {

--- a/config/crd/schema/cluster.ytsaurus.tech_remoteexecnodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remoteexecnodes_v1.json
@@ -1790,6 +1790,27 @@
           "items": {
             "type": "object",
             "properties": {
+              "categoriesFilter": {
+                "description": "Additional include/exclude category filter applied on top of category.",
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                    "type": "string",
+                    "enum": [
+                      "exclude",
+                      "include"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
               "category": {
                 "type": "string"
               },

--- a/config/crd/schema/cluster.ytsaurus.tech_remotetabletnodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remotetabletnodes_v1.json
@@ -1443,6 +1443,27 @@
           "items": {
             "type": "object",
             "properties": {
+              "categoriesFilter": {
+                "description": "Additional include/exclude category filter applied on top of category.",
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                    "type": "string",
+                    "enum": [
+                      "exclude",
+                      "include"
+                    ]
+                  },
+                  "values": {
+                    "type": "array",
+                    "minItems": 1,
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
               "category": {
                 "type": "string"
               },

--- a/config/crd/schema/cluster.ytsaurus.tech_remotetabletnodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remotetabletnodes_v1.json
@@ -1444,7 +1444,7 @@
             "type": "object",
             "properties": {
               "categoriesFilter": {
-                "description": "Additional include/exclude category filter applied on top of category.",
+                "description": "Category filter for logs spanning several categories, as for text loggers.",
                 "type": "object",
                 "properties": {
                   "type": {
@@ -1465,6 +1465,7 @@
                 }
               },
               "category": {
+                "description": "Single category to log.",
                 "type": "string"
               },
               "compression": {

--- a/config/crd/schema/cluster.ytsaurus.tech_remotetabletnodes_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_remotetabletnodes_v1.json
@@ -1444,7 +1444,7 @@
             "type": "object",
             "properties": {
               "categoriesFilter": {
-                "description": "Category filter for logs spanning several categories, as for text loggers.",
+                "description": "Filter for logs spanning several categories. Type must be set.",
                 "type": "object",
                 "properties": {
                   "type": {
@@ -1465,7 +1465,7 @@
                 }
               },
               "category": {
-                "description": "Single category to log.",
+                "description": "Exactly one of category and categoriesFilter must be set.",
                 "type": "string"
               },
               "compression": {

--- a/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
@@ -1282,7 +1282,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -1303,6 +1303,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -3650,7 +3651,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -3671,6 +3672,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -5866,7 +5868,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -5887,6 +5889,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -8088,7 +8091,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "description": "Category filter for logs spanning several categories, as for text loggers.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -8109,6 +8112,7 @@
                       }
                     },
                     "category": {
+                      "description": "Single category to log.",
                       "type": "string"
                     },
                     "compression": {
@@ -10306,7 +10310,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -10327,6 +10331,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -12924,7 +12929,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "description": "Category filter for logs spanning several categories, as for text loggers.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -12945,6 +12950,7 @@
                       }
                     },
                     "category": {
+                      "description": "Single category to log.",
                       "type": "string"
                     },
                     "compression": {
@@ -15210,7 +15216,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "description": "Category filter for logs spanning several categories, as for text loggers.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -15231,6 +15237,7 @@
                       }
                     },
                     "category": {
+                      "description": "Single category to log.",
                       "type": "string"
                     },
                     "compression": {
@@ -17477,7 +17484,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "description": "Category filter for logs spanning several categories, as for text loggers.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -17498,6 +17505,7 @@
                       }
                     },
                     "category": {
+                      "description": "Single category to log.",
                       "type": "string"
                     },
                     "compression": {
@@ -19712,7 +19720,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -19733,6 +19741,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -22088,7 +22097,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -22109,6 +22118,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -24310,7 +24320,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -24331,6 +24341,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -26520,7 +26531,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -26541,6 +26552,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -28749,7 +28761,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "description": "Category filter for logs spanning several categories, as for text loggers.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -28770,6 +28782,7 @@
                       }
                     },
                     "category": {
+                      "description": "Single category to log.",
                       "type": "string"
                     },
                     "compression": {
@@ -31005,7 +31018,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -31026,6 +31039,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -33268,7 +33282,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "description": "Category filter for logs spanning several categories, as for text loggers.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -33289,6 +33303,7 @@
                       }
                     },
                     "category": {
+                      "description": "Single category to log.",
                       "type": "string"
                     },
                     "compression": {
@@ -35706,7 +35721,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -35727,6 +35742,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {
@@ -37927,7 +37943,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "description": "Category filter for logs spanning several categories, as for text loggers.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -37948,6 +37964,7 @@
                       }
                     },
                     "category": {
+                      "description": "Single category to log.",
                       "type": "string"
                     },
                     "compression": {
@@ -40171,7 +40188,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "description": "Category filter for logs spanning several categories, as for text loggers.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -40192,6 +40209,7 @@
                       }
                     },
                     "category": {
+                      "description": "Single category to log.",
                       "type": "string"
                     },
                     "compression": {
@@ -43000,7 +43018,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "description": "Category filter for logs spanning several categories, as for text loggers.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -43021,6 +43039,7 @@
                     }
                   },
                   "category": {
+                    "description": "Single category to log.",
                     "type": "string"
                   },
                   "compression": {

--- a/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
@@ -1281,6 +1281,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -3628,6 +3649,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -5823,6 +5865,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -8024,6 +8087,27 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "categoriesFilter": {
+                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                          "type": "string",
+                          "enum": [
+                            "exclude",
+                            "include"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "category": {
                       "type": "string"
                     },
@@ -10221,6 +10305,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -12818,6 +12923,27 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "categoriesFilter": {
+                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                          "type": "string",
+                          "enum": [
+                            "exclude",
+                            "include"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "category": {
                       "type": "string"
                     },
@@ -15083,6 +15209,27 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "categoriesFilter": {
+                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                          "type": "string",
+                          "enum": [
+                            "exclude",
+                            "include"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "category": {
                       "type": "string"
                     },
@@ -17329,6 +17476,27 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "categoriesFilter": {
+                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                          "type": "string",
+                          "enum": [
+                            "exclude",
+                            "include"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "category": {
                       "type": "string"
                     },
@@ -19543,6 +19711,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -21898,6 +22087,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -24099,6 +24309,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -26288,6 +26519,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -28496,6 +28748,27 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "categoriesFilter": {
+                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                          "type": "string",
+                          "enum": [
+                            "exclude",
+                            "include"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "category": {
                       "type": "string"
                     },
@@ -30731,6 +31004,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -32973,6 +33267,27 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "categoriesFilter": {
+                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                          "type": "string",
+                          "enum": [
+                            "exclude",
+                            "include"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "category": {
                       "type": "string"
                     },
@@ -35390,6 +35705,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },
@@ -37590,6 +37926,27 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "categoriesFilter": {
+                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                          "type": "string",
+                          "enum": [
+                            "exclude",
+                            "include"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "category": {
                       "type": "string"
                     },
@@ -39813,6 +40170,27 @@
                 "items": {
                   "type": "object",
                   "properties": {
+                    "categoriesFilter": {
+                      "description": "Additional include/exclude category filter applied on top of category.",
+                      "type": "object",
+                      "properties": {
+                        "type": {
+                          "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                          "type": "string",
+                          "enum": [
+                            "exclude",
+                            "include"
+                          ]
+                        },
+                        "values": {
+                          "type": "array",
+                          "minItems": 1,
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    },
                     "category": {
                       "type": "string"
                     },
@@ -42621,6 +42999,27 @@
               "items": {
                 "type": "object",
                 "properties": {
+                  "categoriesFilter": {
+                    "description": "Additional include/exclude category filter applied on top of category.",
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "description": "CategoriesFilterType string describes types of possible log CategoriesFilter.",
+                        "type": "string",
+                        "enum": [
+                          "exclude",
+                          "include"
+                        ]
+                      },
+                      "values": {
+                        "type": "array",
+                        "minItems": 1,
+                        "items": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
                   "category": {
                     "type": "string"
                   },

--- a/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
@@ -1282,7 +1282,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -1303,7 +1303,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -3651,7 +3651,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -3672,7 +3672,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -5868,7 +5868,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -5889,7 +5889,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -8091,7 +8091,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Category filter for logs spanning several categories, as for text loggers.",
+                      "description": "Filter for logs spanning several categories. Type must be set.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -8112,7 +8112,7 @@
                       }
                     },
                     "category": {
-                      "description": "Single category to log.",
+                      "description": "Exactly one of category and categoriesFilter must be set.",
                       "type": "string"
                     },
                     "compression": {
@@ -10310,7 +10310,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -10331,7 +10331,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -12929,7 +12929,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Category filter for logs spanning several categories, as for text loggers.",
+                      "description": "Filter for logs spanning several categories. Type must be set.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -12950,7 +12950,7 @@
                       }
                     },
                     "category": {
-                      "description": "Single category to log.",
+                      "description": "Exactly one of category and categoriesFilter must be set.",
                       "type": "string"
                     },
                     "compression": {
@@ -15216,7 +15216,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Category filter for logs spanning several categories, as for text loggers.",
+                      "description": "Filter for logs spanning several categories. Type must be set.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -15237,7 +15237,7 @@
                       }
                     },
                     "category": {
-                      "description": "Single category to log.",
+                      "description": "Exactly one of category and categoriesFilter must be set.",
                       "type": "string"
                     },
                     "compression": {
@@ -17484,7 +17484,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Category filter for logs spanning several categories, as for text loggers.",
+                      "description": "Filter for logs spanning several categories. Type must be set.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -17505,7 +17505,7 @@
                       }
                     },
                     "category": {
-                      "description": "Single category to log.",
+                      "description": "Exactly one of category and categoriesFilter must be set.",
                       "type": "string"
                     },
                     "compression": {
@@ -19720,7 +19720,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -19741,7 +19741,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -22097,7 +22097,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -22118,7 +22118,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -24320,7 +24320,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -24341,7 +24341,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -26531,7 +26531,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -26552,7 +26552,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -28761,7 +28761,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Category filter for logs spanning several categories, as for text loggers.",
+                      "description": "Filter for logs spanning several categories. Type must be set.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -28782,7 +28782,7 @@
                       }
                     },
                     "category": {
-                      "description": "Single category to log.",
+                      "description": "Exactly one of category and categoriesFilter must be set.",
                       "type": "string"
                     },
                     "compression": {
@@ -31018,7 +31018,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -31039,7 +31039,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -33282,7 +33282,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Category filter for logs spanning several categories, as for text loggers.",
+                      "description": "Filter for logs spanning several categories. Type must be set.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -33303,7 +33303,7 @@
                       }
                     },
                     "category": {
-                      "description": "Single category to log.",
+                      "description": "Exactly one of category and categoriesFilter must be set.",
                       "type": "string"
                     },
                     "compression": {
@@ -35721,7 +35721,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -35742,7 +35742,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {
@@ -37943,7 +37943,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Category filter for logs spanning several categories, as for text loggers.",
+                      "description": "Filter for logs spanning several categories. Type must be set.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -37964,7 +37964,7 @@
                       }
                     },
                     "category": {
-                      "description": "Single category to log.",
+                      "description": "Exactly one of category and categoriesFilter must be set.",
                       "type": "string"
                     },
                     "compression": {
@@ -40188,7 +40188,7 @@
                   "type": "object",
                   "properties": {
                     "categoriesFilter": {
-                      "description": "Category filter for logs spanning several categories, as for text loggers.",
+                      "description": "Filter for logs spanning several categories. Type must be set.",
                       "type": "object",
                       "properties": {
                         "type": {
@@ -40209,7 +40209,7 @@
                       }
                     },
                     "category": {
-                      "description": "Single category to log.",
+                      "description": "Exactly one of category and categoriesFilter must be set.",
                       "type": "string"
                     },
                     "compression": {
@@ -43018,7 +43018,7 @@
                 "type": "object",
                 "properties": {
                   "categoriesFilter": {
-                    "description": "Category filter for logs spanning several categories, as for text loggers.",
+                    "description": "Filter for logs spanning several categories. Type must be set.",
                     "type": "object",
                     "properties": {
                       "type": {
@@ -43039,7 +43039,7 @@
                     }
                   },
                   "category": {
-                    "description": "Single category to log.",
+                    "description": "Exactly one of category and categoriesFilter must be set.",
                     "type": "string"
                   },
                   "compression": {

--- a/docs/api.md
+++ b/docs/api.md
@@ -2793,8 +2793,8 @@ _Appears in:_
 | `useTimestampSuffix` _boolean_ |  | false |  |
 | `enableAnchorProfiling` _boolean_ |  |  |  |
 | `rotationPolicy` _[LogRotationPolicy](#logrotationpolicy)_ |  |  |  |
-| `category` _string_ |  |  |  |
-| `categoriesFilter` _[CategoriesFilter](#categoriesfilter)_ | Additional include/exclude category filter applied on top of category.<br />Type must be set. |  |  |
+| `category` _string_ | Single category to log. Exactly one of category and categoriesFilter must be set. |  |  |
+| `categoriesFilter` _[CategoriesFilter](#categoriesfilter)_ | Category filter for logs spanning several categories, as for text loggers.<br />Type must be set. Exactly one of category and categoriesFilter must be set. |  |  |
 | `enableDelivery` _boolean_ | EnableDelivery turns on timbertruck delivery of this structured log to the cluster log storage.<br />Requires a timbertruck image to be configured (spec.timbertruck.image or, for masters, primaryMasters.timbertruck.image). |  |  |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2793,8 +2793,8 @@ _Appears in:_
 | `useTimestampSuffix` _boolean_ |  | false |  |
 | `enableAnchorProfiling` _boolean_ |  |  |  |
 | `rotationPolicy` _[LogRotationPolicy](#logrotationpolicy)_ |  |  |  |
-| `category` _string_ | Single category to log. Exactly one of category and categoriesFilter must be set. |  |  |
-| `categoriesFilter` _[CategoriesFilter](#categoriesfilter)_ | Category filter for logs spanning several categories, as for text loggers.<br />Type must be set. Exactly one of category and categoriesFilter must be set. |  |  |
+| `category` _string_ | Exactly one of category and categoriesFilter must be set. |  |  |
+| `categoriesFilter` _[CategoriesFilter](#categoriesfilter)_ | Filter for logs spanning several categories. Type must be set.<br />Exactly one of category and categoriesFilter must be set. |  |  |
 | `enableDelivery` _boolean_ | EnableDelivery turns on timbertruck delivery of this structured log to the cluster log storage.<br />Requires a timbertruck image to be configured (spec.timbertruck.image or, for masters, primaryMasters.timbertruck.image). |  |  |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -230,6 +230,7 @@ _Appears in:_
 
 
 _Appears in:_
+- [StructuredLoggerSpec](#structuredloggerspec)
 - [TextLoggerSpec](#textloggerspec)
 
 | Field | Description | Default | Validation |
@@ -2793,6 +2794,7 @@ _Appears in:_
 | `enableAnchorProfiling` _boolean_ |  |  |  |
 | `rotationPolicy` _[LogRotationPolicy](#logrotationpolicy)_ |  |  |  |
 | `category` _string_ |  |  |  |
+| `categoriesFilter` _[CategoriesFilter](#categoriesfilter)_ | Additional include/exclude category filter applied on top of category.<br />Lets one logger span several categories, e.g. the scheduler event log is written<br />under both SchedulerStructuredLog and SchedulerEventLog. Type must be set. |  |  |
 | `enableDelivery` _boolean_ | EnableDelivery turns on timbertruck delivery of this structured log to the cluster log storage.<br />Requires a timbertruck image to be configured (spec.timbertruck.image or, for masters, primaryMasters.timbertruck.image). |  |  |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2794,7 +2794,7 @@ _Appears in:_
 | `enableAnchorProfiling` _boolean_ |  |  |  |
 | `rotationPolicy` _[LogRotationPolicy](#logrotationpolicy)_ |  |  |  |
 | `category` _string_ |  |  |  |
-| `categoriesFilter` _[CategoriesFilter](#categoriesfilter)_ | Additional include/exclude category filter applied on top of category.<br />Lets one logger span several categories, e.g. the scheduler event log is written<br />under both SchedulerStructuredLog and SchedulerEventLog. Type must be set. |  |  |
+| `categoriesFilter` _[CategoriesFilter](#categoriesfilter)_ | Additional include/exclude category filter applied on top of category.<br />Type must be set. |  |  |
 | `enableDelivery` _boolean_ | EnableDelivery turns on timbertruck delivery of this structured log to the cluster log storage.<br />Requires a timbertruck image to be configured (spec.timbertruck.image or, for masters, primaryMasters.timbertruck.image). |  |  |
 
 

--- a/pkg/components/canondata/TestGetTimbertruckConfig/test.canondata
+++ b/pkg/components/canondata/TestGetTimbertruckConfig/test.canondata
@@ -6,13 +6,6 @@ json_logs:
   - cluster: http-proxies-lb.ytsaurus-dev.svc.cluster.local
     producer_path: //sys/admin/logs/master-access/producer
     queue_path: //sys/admin/logs/master-access/queue
-- log_file: /yt/master-logs/master.security.log.yson.zstd
-  name: master-security
-  queue_batch_size: 8388608
-  yt_queue:
-  - cluster: http-proxies-lb.ytsaurus-dev.svc.cluster.local
-    producer_path: //sys/admin/logs/master-security/producer
-    queue_path: //sys/admin/logs/master-security/queue
 - log_file: /yt/master-logs/master.other.log.zstd
   name: master-other
   queue_batch_size: 8388608
@@ -21,3 +14,11 @@ json_logs:
     producer_path: //sys/admin/logs/master-other/producer
     queue_path: //sys/admin/logs/master-other/queue
 work_dir: /yt/master-logs/timbertruck
+yson_logs:
+- log_file: /yt/master-logs/master.security.log.yson.zstd
+  name: master-security
+  queue_batch_size: 8388608
+  yt_queue:
+  - cluster: http-proxies-lb.ytsaurus-dev.svc.cluster.local
+    producer_path: //sys/admin/logs/master-security/producer
+    queue_path: //sys/admin/logs/master-security/queue

--- a/pkg/components/pods_manager.go
+++ b/pkg/components/pods_manager.go
@@ -8,6 +8,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/consts"
 	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/labeller"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,6 +61,11 @@ func podContainerIsReady(pod *corev1.Pod, name string) bool {
 func podContainerNames(pod *corev1.Pod, names []string) []string {
 	if len(names) == 0 {
 		for _, ct := range pod.Spec.Containers {
+			// Log delivery must not gate readiness: kubelet restarts the sidecar on its own,
+			// while a failing one would otherwise stall the whole cluster update.
+			if ct.Name == consts.TimbertruckContainerName {
+				continue
+			}
 			names = append(names, ct.Name)
 		}
 	}

--- a/pkg/components/pods_manager.go
+++ b/pkg/components/pods_manager.go
@@ -8,7 +8,6 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/consts"
 	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/labeller"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -61,11 +60,6 @@ func podContainerIsReady(pod *corev1.Pod, name string) bool {
 func podContainerNames(pod *corev1.Pod, names []string) []string {
 	if len(names) == 0 {
 		for _, ct := range pod.Spec.Containers {
-			// Log delivery must not gate readiness: kubelet restarts the sidecar on its own,
-			// while a failing one would otherwise stall the whole cluster update.
-			if ct.Name == consts.TimbertruckContainerName {
-				continue
-			}
 			names = append(names, ct.Name)
 		}
 	}

--- a/pkg/components/timbertruck.go
+++ b/pkg/components/timbertruck.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"path"
-	"slices"
 
 	ytv1 "github.com/ytsaurus/ytsaurus-k8s-operator/api/v1"
 	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/apiproxy"
@@ -488,7 +487,7 @@ func (tt *Timbertruck) prepareTimbertruckTables(ctx context.Context) error {
 }
 
 func prepareTimbertruckTablesFromConfig(ctx context.Context, ytClient yt.Client, timbertruckConfig *ytconfig.TimbertruckConfig, logsDeliveryPath string) error {
-	for _, logConfig := range slices.Concat(timbertruckConfig.JsonLogs, timbertruckConfig.YsonLogs) {
+	for _, logConfig := range timbertruckConfig.AllLogs() {
 		for _, ytQueue := range logConfig.YTQueue {
 			queuePath := ytQueue.QueuePath
 			exportPath := fmt.Sprintf("%s/export/%s", logsDeliveryPath, logConfig.Name)

--- a/pkg/components/timbertruck.go
+++ b/pkg/components/timbertruck.go
@@ -487,7 +487,7 @@ func (tt *Timbertruck) prepareTimbertruckTables(ctx context.Context) error {
 }
 
 func prepareTimbertruckTablesFromConfig(ctx context.Context, ytClient yt.Client, timbertruckConfig *ytconfig.TimbertruckConfig, logsDeliveryPath string) error {
-	for _, logConfig := range timbertruckConfig.AllLogs() {
+	for _, logConfig := range timbertruckConfig.BaseLogConfigs() {
 		for _, ytQueue := range logConfig.YTQueue {
 			queuePath := ytQueue.QueuePath
 			exportPath := fmt.Sprintf("%s/export/%s", logsDeliveryPath, logConfig.Name)

--- a/pkg/components/timbertruck.go
+++ b/pkg/components/timbertruck.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path"
+	"slices"
 
 	ytv1 "github.com/ytsaurus/ytsaurus-k8s-operator/api/v1"
 	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/apiproxy"
@@ -487,10 +488,10 @@ func (tt *Timbertruck) prepareTimbertruckTables(ctx context.Context) error {
 }
 
 func prepareTimbertruckTablesFromConfig(ctx context.Context, ytClient yt.Client, timbertruckConfig *ytconfig.TimbertruckConfig, logsDeliveryPath string) error {
-	for _, jsonLog := range timbertruckConfig.JsonLogs {
-		for _, ytQueue := range jsonLog.YTQueue {
+	for _, logConfig := range slices.Concat(timbertruckConfig.JsonLogs, timbertruckConfig.YsonLogs) {
+		for _, ytQueue := range logConfig.YTQueue {
 			queuePath := ytQueue.QueuePath
-			exportPath := fmt.Sprintf("%s/export/%s", logsDeliveryPath, jsonLog.Name)
+			exportPath := fmt.Sprintf("%s/export/%s", logsDeliveryPath, logConfig.Name)
 			if err := prepareQueue(ctx, ytClient, queuePath, exportPath); err != nil {
 				return fmt.Errorf("failed to prepare YT queue %s with export destination %s: %w", queuePath, exportPath, err)
 			}

--- a/pkg/components/timbertruck_test.go
+++ b/pkg/components/timbertruck_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 
 	v1 "github.com/ytsaurus/ytsaurus-k8s-operator/api/v1"
 	"github.com/ytsaurus/ytsaurus-k8s-operator/pkg/canonize"
@@ -22,7 +23,7 @@ func TestGetTimbertruckConfig(t *testing.T) {
 	timbertruckConfig := ytconfig.NewTimbertruckConfig(
 		[]v1.StructuredLoggerSpec{
 			{
-				Category: "Access",
+				Category: ptr.To("Access"),
 				BaseLoggerSpec: v1.BaseLoggerSpec{
 					Name:               "access",
 					Format:             v1.LogFormatJson,
@@ -31,7 +32,7 @@ func TestGetTimbertruckConfig(t *testing.T) {
 				},
 			},
 			{
-				Category: "Security",
+				Category: ptr.To("Security"),
 				BaseLoggerSpec: v1.BaseLoggerSpec{
 					Name:        "security",
 					Format:      v1.LogFormatYson,
@@ -39,7 +40,7 @@ func TestGetTimbertruckConfig(t *testing.T) {
 				},
 			},
 			{
-				Category: "Other",
+				Category: ptr.To("Other"),
 				BaseLoggerSpec: v1.BaseLoggerSpec{
 					Name:        "other",
 					Format:      v1.LogFormatPlainText,

--- a/pkg/ytconfig/logging.go
+++ b/pkg/ytconfig/logging.go
@@ -3,7 +3,6 @@ package ytconfig
 import (
 	"fmt"
 	"path"
-	"slices"
 	"time"
 
 	"go.ytsaurus.tech/yt/go/yson"
@@ -240,7 +239,6 @@ func createBaseLoggingRule(spec ytv1.BaseLoggerSpec) LoggingRule {
 	}
 }
 
-// applyCategoriesFilter merges a filter into a rule, skipping already included categories.
 func applyCategoriesFilter(loggingRule *LoggingRule, filter *ytv1.CategoriesFilter) {
 	if filter == nil {
 		return
@@ -251,11 +249,7 @@ func applyCategoriesFilter(loggingRule *LoggingRule, filter *ytv1.CategoriesFilt
 		loggingRule.ExcludeCategories = append(loggingRule.ExcludeCategories, filter.Values...)
 
 	case ytv1.CategoriesFilterTypeInclude:
-		for _, category := range filter.Values {
-			if !slices.Contains(loggingRule.IncludeCategories, category) {
-				loggingRule.IncludeCategories = append(loggingRule.IncludeCategories, category)
-			}
-		}
+		loggingRule.IncludeCategories = append(loggingRule.IncludeCategories, filter.Values...)
 	}
 }
 
@@ -271,17 +265,9 @@ func createLoggingRule(spec ytv1.TextLoggerSpec) LoggingRule {
 func createStructuredLoggingRule(spec ytv1.StructuredLoggerSpec) LoggingRule {
 	loggingRule := createBaseLoggingRule(spec.BaseLoggerSpec)
 	loggingRule.Family = ptr.To(LogFamilyStructured)
-	if spec.Category != "" {
-		loggingRule.IncludeCategories = []string{spec.Category}
-	}
+	loggingRule.IncludeCategories = []string{spec.Category}
 
 	applyCategoriesFilter(&loggingRule, spec.CategoriesFilter)
-
-	// An absent include list would make the rule match every category.
-	if loggingRule.IncludeCategories == nil {
-		loggingRule.IncludeCategories = []string{spec.Category}
-	}
-
 	return loggingRule
 }
 

--- a/pkg/ytconfig/logging.go
+++ b/pkg/ytconfig/logging.go
@@ -269,7 +269,7 @@ func createStructuredLoggingRule(spec ytv1.StructuredLoggerSpec) LoggingRule {
 	if spec.CategoriesFilter != nil {
 		applyCategoriesFilter(&loggingRule, spec.CategoriesFilter)
 	} else {
-		loggingRule.IncludeCategories = []string{spec.Category}
+		loggingRule.IncludeCategories = []string{ptr.Deref(spec.Category, "")}
 	}
 	return loggingRule
 }

--- a/pkg/ytconfig/logging.go
+++ b/pkg/ytconfig/logging.go
@@ -3,6 +3,7 @@ package ytconfig
 import (
 	"fmt"
 	"path"
+	"slices"
 	"time"
 
 	"go.ytsaurus.tech/yt/go/yson"
@@ -239,27 +240,53 @@ func createBaseLoggingRule(spec ytv1.BaseLoggerSpec) LoggingRule {
 	}
 }
 
+// applyCategoriesFilter merges a categories filter into a logging rule. Include values are
+// appended to the categories already selected by the rule, skipping duplicates.
+func applyCategoriesFilter(loggingRule *LoggingRule, filter *ytv1.CategoriesFilter) {
+	if filter == nil {
+		return
+	}
+
+	switch filter.Type {
+	case ytv1.CategoriesFilterTypeExclude:
+		loggingRule.ExcludeCategories = append(loggingRule.ExcludeCategories, filter.Values...)
+
+	case ytv1.CategoriesFilterTypeInclude:
+		for _, category := range filter.Values {
+			if !slices.Contains(loggingRule.IncludeCategories, category) {
+				loggingRule.IncludeCategories = append(loggingRule.IncludeCategories, category)
+			}
+		}
+	}
+}
+
 func createLoggingRule(spec ytv1.TextLoggerSpec) LoggingRule {
 	loggingRule := createBaseLoggingRule(spec.BaseLoggerSpec)
 
 	loggingRule.Family = ptr.To(LogFamilyPlainText)
 
-	if spec.CategoriesFilter != nil {
-		switch spec.CategoriesFilter.Type {
-		case ytv1.CategoriesFilterTypeExclude:
-			loggingRule.ExcludeCategories = append(loggingRule.ExcludeCategories, spec.CategoriesFilter.Values...)
-
-		case ytv1.CategoriesFilterTypeInclude:
-			loggingRule.IncludeCategories = append(loggingRule.IncludeCategories, spec.CategoriesFilter.Values...)
-		}
-	}
+	applyCategoriesFilter(&loggingRule, spec.CategoriesFilter)
 	return loggingRule
 }
 
+// createStructuredLoggingRule selects the categories of a structured logger. Some structured logs
+// span several categories (e.g. the scheduler event log is written under both SchedulerStructuredLog
+// and SchedulerEventLog), so categoriesFilter may add categories to the single category field.
 func createStructuredLoggingRule(spec ytv1.StructuredLoggerSpec) LoggingRule {
 	loggingRule := createBaseLoggingRule(spec.BaseLoggerSpec)
 	loggingRule.Family = ptr.To(LogFamilyStructured)
-	loggingRule.IncludeCategories = []string{spec.Category}
+	if spec.Category != "" {
+		loggingRule.IncludeCategories = []string{spec.Category}
+	}
+
+	applyCategoriesFilter(&loggingRule, spec.CategoriesFilter)
+
+	// An absent include list makes the rule match every category, so a structured rule always keeps
+	// one: without it a logger with neither category nor include filter would silently widen from
+	// matching nothing to matching everything.
+	if loggingRule.IncludeCategories == nil {
+		loggingRule.IncludeCategories = []string{spec.Category}
+	}
 
 	return loggingRule
 }

--- a/pkg/ytconfig/logging.go
+++ b/pkg/ytconfig/logging.go
@@ -265,9 +265,12 @@ func createLoggingRule(spec ytv1.TextLoggerSpec) LoggingRule {
 func createStructuredLoggingRule(spec ytv1.StructuredLoggerSpec) LoggingRule {
 	loggingRule := createBaseLoggingRule(spec.BaseLoggerSpec)
 	loggingRule.Family = ptr.To(LogFamilyStructured)
-	loggingRule.IncludeCategories = []string{spec.Category}
 
-	applyCategoriesFilter(&loggingRule, spec.CategoriesFilter)
+	if spec.CategoriesFilter != nil {
+		applyCategoriesFilter(&loggingRule, spec.CategoriesFilter)
+	} else {
+		loggingRule.IncludeCategories = []string{spec.Category}
+	}
 	return loggingRule
 }
 

--- a/pkg/ytconfig/logging.go
+++ b/pkg/ytconfig/logging.go
@@ -240,8 +240,7 @@ func createBaseLoggingRule(spec ytv1.BaseLoggerSpec) LoggingRule {
 	}
 }
 
-// applyCategoriesFilter merges a categories filter into a logging rule. Include values are
-// appended to the categories already selected by the rule, skipping duplicates.
+// applyCategoriesFilter merges a filter into a rule, skipping already included categories.
 func applyCategoriesFilter(loggingRule *LoggingRule, filter *ytv1.CategoriesFilter) {
 	if filter == nil {
 		return
@@ -269,9 +268,6 @@ func createLoggingRule(spec ytv1.TextLoggerSpec) LoggingRule {
 	return loggingRule
 }
 
-// createStructuredLoggingRule selects the categories of a structured logger. Some structured logs
-// span several categories (e.g. the scheduler event log is written under both SchedulerStructuredLog
-// and SchedulerEventLog), so categoriesFilter may add categories to the single category field.
 func createStructuredLoggingRule(spec ytv1.StructuredLoggerSpec) LoggingRule {
 	loggingRule := createBaseLoggingRule(spec.BaseLoggerSpec)
 	loggingRule.Family = ptr.To(LogFamilyStructured)
@@ -281,9 +277,7 @@ func createStructuredLoggingRule(spec ytv1.StructuredLoggerSpec) LoggingRule {
 
 	applyCategoriesFilter(&loggingRule, spec.CategoriesFilter)
 
-	// An absent include list makes the rule match every category, so a structured rule always keeps
-	// one: without it a logger with neither category nor include filter would silently widen from
-	// matching nothing to matching everything.
+	// An absent include list would make the rule match every category.
 	if loggingRule.IncludeCategories == nil {
 		loggingRule.IncludeCategories = []string{spec.Category}
 	}

--- a/pkg/ytconfig/logging_test.go
+++ b/pkg/ytconfig/logging_test.go
@@ -1,0 +1,53 @@
+package ytconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ytv1 "github.com/ytsaurus/ytsaurus-k8s-operator/api/v1"
+)
+
+func TestCreateStructuredLoggingRule(t *testing.T) {
+	for _, testCase := range []struct {
+		name              string
+		spec              ytv1.StructuredLoggerSpec
+		includeCategories []string
+		excludeCategories []string
+	}{
+		{
+			name:              "category",
+			spec:              ytv1.StructuredLoggerSpec{Category: "Access"},
+			includeCategories: []string{"Access"},
+		},
+		{
+			// The scheduler event log spans both of these.
+			name: "include filter replaces category",
+			spec: ytv1.StructuredLoggerSpec{CategoriesFilter: &ytv1.CategoriesFilter{
+				Type:   ytv1.CategoriesFilterTypeInclude,
+				Values: []string{"SchedulerStructuredLog", "SchedulerEventLog"},
+			}},
+			includeCategories: []string{"SchedulerStructuredLog", "SchedulerEventLog"},
+		},
+		{
+			name: "exclude filter",
+			spec: ytv1.StructuredLoggerSpec{CategoriesFilter: &ytv1.CategoriesFilter{
+				Type:   ytv1.CategoriesFilterTypeExclude,
+				Values: []string{"Barrier"},
+			}},
+			excludeCategories: []string{"Barrier"},
+		},
+		{
+			// An empty category must not turn into an absent include list, which matches everything.
+			name:              "empty category",
+			spec:              ytv1.StructuredLoggerSpec{},
+			includeCategories: []string{""},
+		},
+	} {
+		t.Run(testCase.name, func(t *testing.T) {
+			rule := createStructuredLoggingRule(testCase.spec)
+			require.Equal(t, testCase.includeCategories, rule.IncludeCategories)
+			require.Equal(t, testCase.excludeCategories, rule.ExcludeCategories)
+		})
+	}
+}

--- a/pkg/ytconfig/logging_test.go
+++ b/pkg/ytconfig/logging_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
 
 	ytv1 "github.com/ytsaurus/ytsaurus-k8s-operator/api/v1"
 )
@@ -17,7 +18,7 @@ func TestCreateStructuredLoggingRule(t *testing.T) {
 	}{
 		{
 			name:              "category",
-			spec:              ytv1.StructuredLoggerSpec{Category: "Access"},
+			spec:              ytv1.StructuredLoggerSpec{Category: ptr.To("Access")},
 			includeCategories: []string{"Access"},
 		},
 		{

--- a/pkg/ytconfig/timbertruck.go
+++ b/pkg/ytconfig/timbertruck.go
@@ -12,17 +12,39 @@ import (
 type TimbertruckConfig struct {
 	WorkDir string `json:"work_dir" yson:"work_dir"`
 	// Timbertruck validates each section in its own format and drops unparsable lines.
-	JsonLogs []TimbertruckLogConfig `json:"json_logs,omitempty" yson:"json_logs,omitempty"`
-	YsonLogs []TimbertruckLogConfig `json:"yson_logs,omitempty" yson:"yson_logs,omitempty"`
+	JsonLogs []TimbertruckJsonLogConfig `json:"json_logs,omitempty" yson:"json_logs,omitempty"`
+	YsonLogs []TimbertruckYsonLogConfig `json:"yson_logs,omitempty" yson:"yson_logs,omitempty"`
 }
 
 const timbertruckQueueBatchSize = 8 * 1024 * 1024 // 8 MiB
 
-type TimbertruckLogConfig struct {
+type TimbertruckBaseLogConfig struct {
 	Name           string                     `json:"name" yson:"name"`
 	LogFile        string                     `json:"log_file" yson:"log_file"`
 	QueueBatchSize int                        `json:"queue_batch_size" yson:"queue_batch_size"`
 	YTQueue        []TimbertruckYTQueueConfig `json:"yt_queue" yson:"yt_queue"`
+}
+
+// Identical to TimbertruckYsonLogConfig today, kept apart as timbertruck keeps its own
+// JSONLogConfig and YSONLogConfig, so that the sections can diverge.
+type TimbertruckJsonLogConfig struct {
+	TimbertruckBaseLogConfig
+}
+
+type TimbertruckYsonLogConfig struct {
+	TimbertruckBaseLogConfig
+}
+
+// AllLogs returns every configured log regardless of its section.
+func (c *TimbertruckConfig) AllLogs() []TimbertruckBaseLogConfig {
+	logs := make([]TimbertruckBaseLogConfig, 0, len(c.JsonLogs)+len(c.YsonLogs))
+	for _, logConfig := range c.JsonLogs {
+		logs = append(logs, logConfig.TimbertruckBaseLogConfig)
+	}
+	for _, logConfig := range c.YsonLogs {
+		logs = append(logs, logConfig.TimbertruckBaseLogConfig)
+	}
+	return logs
 }
 
 type TimbertruckYTQueueConfig struct {
@@ -54,7 +76,7 @@ func NewTimbertruckConfig(
 			fileName += fmt.Sprintf(".%s", structuredLogger.Compression)
 		}
 
-		timbertruckLogConfig := TimbertruckLogConfig{
+		baseLogConfig := TimbertruckBaseLogConfig{
 			Name:           deliveryName,
 			LogFile:        fileName,
 			QueueBatchSize: timbertruckQueueBatchSize,
@@ -63,16 +85,16 @@ func NewTimbertruckConfig(
 
 		deliveryPath := fmt.Sprintf("%s/%s", logsDeliveryPath, deliveryName)
 
-		timbertruckLogConfig.YTQueue = append(timbertruckLogConfig.YTQueue, TimbertruckYTQueueConfig{
+		baseLogConfig.YTQueue = append(baseLogConfig.YTQueue, TimbertruckYTQueueConfig{
 			Cluster:      deliveryProxy,
 			QueuePath:    fmt.Sprintf("%s/queue", deliveryPath),
 			ProducerPath: fmt.Sprintf("%s/producer", deliveryPath),
 		})
 
 		if structuredLogger.Format == ytv1.LogFormatYson {
-			timbertruckConfig.YsonLogs = append(timbertruckConfig.YsonLogs, timbertruckLogConfig)
+			timbertruckConfig.YsonLogs = append(timbertruckConfig.YsonLogs, TimbertruckYsonLogConfig{baseLogConfig})
 		} else {
-			timbertruckConfig.JsonLogs = append(timbertruckConfig.JsonLogs, timbertruckLogConfig)
+			timbertruckConfig.JsonLogs = append(timbertruckConfig.JsonLogs, TimbertruckJsonLogConfig{baseLogConfig})
 		}
 	}
 

--- a/pkg/ytconfig/timbertruck.go
+++ b/pkg/ytconfig/timbertruck.go
@@ -10,8 +10,12 @@ import (
 )
 
 type TimbertruckConfig struct {
-	WorkDir  string                     `json:"work_dir" yson:"work_dir"`
-	JsonLogs []TimbertruckJsonLogConfig `json:"json_logs" yson:"json_logs"`
+	WorkDir string `json:"work_dir" yson:"work_dir"`
+	// JsonLogs and YsonLogs are tracked by separate timbertruck pipelines: each one validates every
+	// line in its own format and drops the lines it cannot parse, so a logger must be listed under
+	// the section matching its format.
+	JsonLogs []TimbertruckJsonLogConfig `json:"json_logs,omitempty" yson:"json_logs,omitempty"`
+	YsonLogs []TimbertruckJsonLogConfig `json:"yson_logs,omitempty" yson:"yson_logs,omitempty"`
 }
 
 const timbertruckQueueBatchSize = 8 * 1024 * 1024 // 8 MiB
@@ -38,8 +42,7 @@ func NewTimbertruckConfig(
 	logsDeliveryPath string,
 ) *TimbertruckConfig {
 	timbertruckConfig := &TimbertruckConfig{
-		WorkDir:  workDir,
-		JsonLogs: []TimbertruckJsonLogConfig{},
+		WorkDir: workDir,
 	}
 
 	for _, structuredLogger := range structuredLoggers {
@@ -68,10 +71,14 @@ func NewTimbertruckConfig(
 			ProducerPath: fmt.Sprintf("%s/producer", deliveryPath),
 		})
 
-		timbertruckConfig.JsonLogs = append(timbertruckConfig.JsonLogs, timbertruckJsonLogConfig)
+		if structuredLogger.Format == ytv1.LogFormatYson {
+			timbertruckConfig.YsonLogs = append(timbertruckConfig.YsonLogs, timbertruckJsonLogConfig)
+		} else {
+			timbertruckConfig.JsonLogs = append(timbertruckConfig.JsonLogs, timbertruckJsonLogConfig)
+		}
 	}
 
-	if len(timbertruckConfig.JsonLogs) == 0 {
+	if len(timbertruckConfig.JsonLogs) == 0 && len(timbertruckConfig.YsonLogs) == 0 {
 		return nil
 	}
 

--- a/pkg/ytconfig/timbertruck.go
+++ b/pkg/ytconfig/timbertruck.go
@@ -12,13 +12,13 @@ import (
 type TimbertruckConfig struct {
 	WorkDir string `json:"work_dir" yson:"work_dir"`
 	// Timbertruck validates each section in its own format and drops unparsable lines.
-	JsonLogs []TimbertruckJsonLogConfig `json:"json_logs,omitempty" yson:"json_logs,omitempty"`
-	YsonLogs []TimbertruckJsonLogConfig `json:"yson_logs,omitempty" yson:"yson_logs,omitempty"`
+	JsonLogs []TimbertruckLogConfig `json:"json_logs,omitempty" yson:"json_logs,omitempty"`
+	YsonLogs []TimbertruckLogConfig `json:"yson_logs,omitempty" yson:"yson_logs,omitempty"`
 }
 
 const timbertruckQueueBatchSize = 8 * 1024 * 1024 // 8 MiB
 
-type TimbertruckJsonLogConfig struct {
+type TimbertruckLogConfig struct {
 	Name           string                     `json:"name" yson:"name"`
 	LogFile        string                     `json:"log_file" yson:"log_file"`
 	QueueBatchSize int                        `json:"queue_batch_size" yson:"queue_batch_size"`
@@ -54,7 +54,7 @@ func NewTimbertruckConfig(
 			fileName += fmt.Sprintf(".%s", structuredLogger.Compression)
 		}
 
-		timbertruckJsonLogConfig := TimbertruckJsonLogConfig{
+		timbertruckLogConfig := TimbertruckLogConfig{
 			Name:           deliveryName,
 			LogFile:        fileName,
 			QueueBatchSize: timbertruckQueueBatchSize,
@@ -63,16 +63,16 @@ func NewTimbertruckConfig(
 
 		deliveryPath := fmt.Sprintf("%s/%s", logsDeliveryPath, deliveryName)
 
-		timbertruckJsonLogConfig.YTQueue = append(timbertruckJsonLogConfig.YTQueue, TimbertruckYTQueueConfig{
+		timbertruckLogConfig.YTQueue = append(timbertruckLogConfig.YTQueue, TimbertruckYTQueueConfig{
 			Cluster:      deliveryProxy,
 			QueuePath:    fmt.Sprintf("%s/queue", deliveryPath),
 			ProducerPath: fmt.Sprintf("%s/producer", deliveryPath),
 		})
 
 		if structuredLogger.Format == ytv1.LogFormatYson {
-			timbertruckConfig.YsonLogs = append(timbertruckConfig.YsonLogs, timbertruckJsonLogConfig)
+			timbertruckConfig.YsonLogs = append(timbertruckConfig.YsonLogs, timbertruckLogConfig)
 		} else {
-			timbertruckConfig.JsonLogs = append(timbertruckConfig.JsonLogs, timbertruckJsonLogConfig)
+			timbertruckConfig.JsonLogs = append(timbertruckConfig.JsonLogs, timbertruckLogConfig)
 		}
 	}
 

--- a/pkg/ytconfig/timbertruck.go
+++ b/pkg/ytconfig/timbertruck.go
@@ -25,8 +25,6 @@ type TimbertruckBaseLogConfig struct {
 	YTQueue        []TimbertruckYTQueueConfig `json:"yt_queue" yson:"yt_queue"`
 }
 
-// Identical to TimbertruckYsonLogConfig today, kept apart as timbertruck keeps its own
-// JSONLogConfig and YSONLogConfig, so that the sections can diverge.
 type TimbertruckJsonLogConfig struct {
 	TimbertruckBaseLogConfig
 }
@@ -35,8 +33,8 @@ type TimbertruckYsonLogConfig struct {
 	TimbertruckBaseLogConfig
 }
 
-// AllLogs returns every configured log regardless of its section.
-func (c *TimbertruckConfig) AllLogs() []TimbertruckBaseLogConfig {
+// BaseLogConfigs returns every configured log regardless of its section.
+func (c *TimbertruckConfig) BaseLogConfigs() []TimbertruckBaseLogConfig {
 	logs := make([]TimbertruckBaseLogConfig, 0, len(c.JsonLogs)+len(c.YsonLogs))
 	for _, logConfig := range c.JsonLogs {
 		logs = append(logs, logConfig.TimbertruckBaseLogConfig)

--- a/pkg/ytconfig/timbertruck.go
+++ b/pkg/ytconfig/timbertruck.go
@@ -11,9 +11,7 @@ import (
 
 type TimbertruckConfig struct {
 	WorkDir string `json:"work_dir" yson:"work_dir"`
-	// JsonLogs and YsonLogs are tracked by separate timbertruck pipelines: each one validates every
-	// line in its own format and drops the lines it cannot parse, so a logger must be listed under
-	// the section matching its format.
+	// Timbertruck validates each section in its own format and drops unparsable lines.
 	JsonLogs []TimbertruckJsonLogConfig `json:"json_logs,omitempty" yson:"json_logs,omitempty"`
 	YsonLogs []TimbertruckJsonLogConfig `json:"yson_logs,omitempty" yson:"yson_logs,omitempty"`
 }

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -1521,7 +1521,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				ytsaurus.Spec.PrimaryMasters.InstanceSpec.StructuredLoggers = append(
 					ytsaurus.Spec.PrimaryMasters.InstanceSpec.StructuredLoggers,
 					ytv1.StructuredLoggerSpec{
-						Category: "Access",
+						Category: ptr.To("Access"),
 						BaseLoggerSpec: ytv1.BaseLoggerSpec{
 							Name:   "access",
 							Format: ytv1.LogFormatJson,
@@ -1622,7 +1622,7 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 				ytsaurus.Spec.HTTPProxies[0].InstanceSpec.StructuredLoggers = append(
 					ytsaurus.Spec.HTTPProxies[0].InstanceSpec.StructuredLoggers,
 					ytv1.StructuredLoggerSpec{
-						Category: "Access",
+						Category: ptr.To("Access"),
 						BaseLoggerSpec: ytv1.BaseLoggerSpec{
 							Name:   "access",
 							Format: ytv1.LogFormatJson,

--- a/test/r8r/components_test.go
+++ b/test/r8r/components_test.go
@@ -706,7 +706,7 @@ var _ = Describe("Components reconciler", Label("reconciler"), func() {
 			ytsaurus.Spec.PrimaryMasters.InstanceSpec.StructuredLoggers = append(
 				ytsaurus.Spec.PrimaryMasters.InstanceSpec.StructuredLoggers,
 				ytv1.StructuredLoggerSpec{
-					Category: "Access",
+					Category: ptr.To("Access"),
 					BaseLoggerSpec: ytv1.BaseLoggerSpec{
 						Name:   "access",
 						Format: ytv1.LogFormatJson,

--- a/test/webhooks/ytsaurus_webhooks_test.go
+++ b/test/webhooks/ytsaurus_webhooks_test.go
@@ -419,7 +419,7 @@ var _ = Describe("Test for Ytsaurus webhooks", func() {
 
 		It("Should accept Timbertruck with structured loggers, logs location and Image", func() {
 			ytsaurus.Spec.PrimaryMasters.Timbertruck = &ytv1.TimbertruckSpec{Image: ptr.To("ghcr.io/ytsaurus/sidecars:0.0.0")}
-			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{BaseLoggerSpec: ytv1.BaseLoggerSpec{Name: "access"}, Category: "Access"}}
+			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{BaseLoggerSpec: ytv1.BaseLoggerSpec{Name: "access"}, Category: ptr.To("Access")}}
 			ytsaurus.Spec.PrimaryMasters.Locations = append(ytsaurus.Spec.PrimaryMasters.Locations, ytv1.LocationSpec{LocationType: ytv1.LocationTypeLogs, Path: "/yt/master-logs"})
 			ytsaurus.Spec.PrimaryMasters.VolumeMounts = append(ytsaurus.Spec.PrimaryMasters.VolumeMounts, corev1.VolumeMount{Name: "master-logs", MountPath: "/yt/master-logs"})
 
@@ -440,7 +440,7 @@ var _ = Describe("Test for Ytsaurus webhooks", func() {
 		It("Should not accept structured logger with both category and categories filter", func() {
 			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{
 				BaseLoggerSpec:   ytv1.BaseLoggerSpec{Name: "event"},
-				Category:         "Access",
+				Category:         ptr.To("Access"),
 				CategoriesFilter: &ytv1.CategoriesFilter{Type: ytv1.CategoriesFilterTypeInclude, Values: []string{"Security"}},
 			}}
 
@@ -470,9 +470,20 @@ var _ = Describe("Test for Ytsaurus webhooks", func() {
 			))
 		})
 
+		It("Should not accept structured logger with empty category", func() {
+			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{
+				BaseLoggerSpec: ytv1.BaseLoggerSpec{Name: "event"},
+				Category:       ptr.To(""),
+			}}
+
+			Expect(k8sClient.Create(ctx, ytsaurus)).Should(MatchError(
+				ContainSubstring("category must not be empty"),
+			))
+		})
+
 		It("Should not accept Timbertruck with uncovered log location", func() {
 			ytsaurus.Spec.PrimaryMasters.Timbertruck = &ytv1.TimbertruckSpec{Image: ptr.To("ghcr.io/ytsaurus/sidecars:0.0.0")}
-			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{BaseLoggerSpec: ytv1.BaseLoggerSpec{Name: "access"}, Category: "Access"}}
+			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{BaseLoggerSpec: ytv1.BaseLoggerSpec{Name: "access"}, Category: ptr.To("Access")}}
 
 			ytsaurus.Spec.PrimaryMasters.Locations = []ytv1.LocationSpec{
 				{LocationType: ytv1.LocationTypeLogs, Path: "/yt/uncovered-logs"},

--- a/test/webhooks/ytsaurus_webhooks_test.go
+++ b/test/webhooks/ytsaurus_webhooks_test.go
@@ -449,6 +449,17 @@ var _ = Describe("Test for Ytsaurus webhooks", func() {
 			))
 		})
 
+		It("Should not accept structured logger with categories filter missing type or values", func() {
+			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{
+				BaseLoggerSpec:   ytv1.BaseLoggerSpec{Name: "event"},
+				CategoriesFilter: &ytv1.CategoriesFilter{Values: []string{"Access"}},
+			}}
+
+			Expect(k8sClient.Create(ctx, ytsaurus)).Should(MatchError(
+				ContainSubstring("categoriesFilter requires type and values"),
+			))
+		})
+
 		It("Should not accept structured logger with neither category nor categories filter", func() {
 			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{
 				BaseLoggerSpec: ytv1.BaseLoggerSpec{Name: "event"},

--- a/test/webhooks/ytsaurus_webhooks_test.go
+++ b/test/webhooks/ytsaurus_webhooks_test.go
@@ -427,6 +427,38 @@ var _ = Describe("Test for Ytsaurus webhooks", func() {
 			Expect(k8sClient.Delete(ctx, ytsaurus)).Should(Succeed())
 		})
 
+		It("Should accept structured logger with categories filter instead of category", func() {
+			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{
+				BaseLoggerSpec:   ytv1.BaseLoggerSpec{Name: "event"},
+				CategoriesFilter: &ytv1.CategoriesFilter{Type: ytv1.CategoriesFilterTypeInclude, Values: []string{"Access", "Security"}},
+			}}
+
+			Expect(k8sClient.Create(ctx, ytsaurus)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, ytsaurus)).Should(Succeed())
+		})
+
+		It("Should not accept structured logger with both category and categories filter", func() {
+			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{
+				BaseLoggerSpec:   ytv1.BaseLoggerSpec{Name: "event"},
+				Category:         "Access",
+				CategoriesFilter: &ytv1.CategoriesFilter{Type: ytv1.CategoriesFilterTypeInclude, Values: []string{"Security"}},
+			}}
+
+			Expect(k8sClient.Create(ctx, ytsaurus)).Should(MatchError(
+				ContainSubstring("exactly one of category and categoriesFilter must be set"),
+			))
+		})
+
+		It("Should not accept structured logger with neither category nor categories filter", func() {
+			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{
+				BaseLoggerSpec: ytv1.BaseLoggerSpec{Name: "event"},
+			}}
+
+			Expect(k8sClient.Create(ctx, ytsaurus)).Should(MatchError(
+				ContainSubstring("exactly one of category and categoriesFilter must be set"),
+			))
+		})
+
 		It("Should not accept Timbertruck with uncovered log location", func() {
 			ytsaurus.Spec.PrimaryMasters.Timbertruck = &ytv1.TimbertruckSpec{Image: ptr.To("ghcr.io/ytsaurus/sidecars:0.0.0")}
 			ytsaurus.Spec.PrimaryMasters.StructuredLoggers = []ytv1.StructuredLoggerSpec{{BaseLoggerSpec: ytv1.BaseLoggerSpec{Name: "access"}, Category: "Access"}}

--- a/validators/remote_timbertruck_webhook.go
+++ b/validators/remote_timbertruck_webhook.go
@@ -40,6 +40,7 @@ func validateRemoteTimbertruck(commonSpec *ytv1.CommonSpec, instanceSpec *ytv1.I
 			))
 		}
 	}
+	allErrors = append(allErrors, validateStructuredLoggers(instanceSpec.StructuredLoggers, specPath)...)
 	return allErrors
 }
 

--- a/validators/remote_timbertruck_webhook_test.go
+++ b/validators/remote_timbertruck_webhook_test.go
@@ -27,7 +27,7 @@ func TestValidateRemoteTimbertruck(t *testing.T) {
 		errors := validateRemoteTimbertruck(
 			&ytv1.CommonSpec{},
 			&ytv1.InstanceSpec{StructuredLoggers: []ytv1.StructuredLoggerSpec{{
-				Category:       "Access",
+				Category:       ptr.To("Access"),
 				EnableDelivery: ptr.To(false),
 			}}},
 		)

--- a/validators/remote_timbertruck_webhook_test.go
+++ b/validators/remote_timbertruck_webhook_test.go
@@ -27,10 +27,20 @@ func TestValidateRemoteTimbertruck(t *testing.T) {
 		errors := validateRemoteTimbertruck(
 			&ytv1.CommonSpec{},
 			&ytv1.InstanceSpec{StructuredLoggers: []ytv1.StructuredLoggerSpec{{
+				Category:       "Access",
 				EnableDelivery: ptr.To(false),
 			}}},
 		)
 		require.Len(t, errors, 1)
 		require.Equal(t, "spec.structuredLoggers[0].enableDelivery", errors[0].Field)
+	})
+
+	t.Run("rejects structured logger without categories", func(t *testing.T) {
+		errors := validateRemoteTimbertruck(
+			&ytv1.CommonSpec{},
+			&ytv1.InstanceSpec{StructuredLoggers: []ytv1.StructuredLoggerSpec{{}}},
+		)
+		require.Len(t, errors, 1)
+		require.Equal(t, "spec.structuredLoggers[0]", errors[0].Field)
 	})
 }

--- a/validators/ytsaurus_webhook.go
+++ b/validators/ytsaurus_webhook.go
@@ -420,9 +420,14 @@ func validateStructuredLoggers(structuredLoggers []ytv1.StructuredLoggerSpec, pa
 	for loggerIdx, logger := range structuredLoggers {
 		loggerPath := parentPath.Child("structuredLoggers").Index(loggerIdx)
 
-		if (logger.Category != "") == (logger.CategoriesFilter != nil) {
+		if (logger.Category != nil) == (logger.CategoriesFilter != nil) {
 			allErrors = append(allErrors, field.Invalid(loggerPath, logger.Name,
 				"exactly one of category and categoriesFilter must be set"))
+		}
+		// Otherwise the rule matches no category at all.
+		if logger.Category != nil && *logger.Category == "" {
+			allErrors = append(allErrors, field.Required(loggerPath.Child("category"),
+				"category must not be empty"))
 		}
 		// Without both, the rule ends up with no category restriction and matches every category.
 		if filter := logger.CategoriesFilter; filter != nil && (filter.Type == "" || len(filter.Values) == 0) {

--- a/validators/ytsaurus_webhook.go
+++ b/validators/ytsaurus_webhook.go
@@ -424,7 +424,6 @@ func validateStructuredLoggers(structuredLoggers []ytv1.StructuredLoggerSpec, pa
 			allErrors = append(allErrors, field.Invalid(loggerPath, logger.Name,
 				"exactly one of category and categoriesFilter must be set"))
 		}
-		// Otherwise the rule matches no category at all.
 		if logger.Category != nil && *logger.Category == "" {
 			allErrors = append(allErrors, field.Required(loggerPath.Child("category"),
 				"category must not be empty"))

--- a/validators/ytsaurus_webhook.go
+++ b/validators/ytsaurus_webhook.go
@@ -414,6 +414,20 @@ func (r *baseValidator) validateTimbertruckSpec(
 	return allErrors
 }
 
+func (r *baseValidator) validateStructuredLoggers(structuredLoggers []ytv1.StructuredLoggerSpec, parentPath *field.Path) field.ErrorList {
+	var allErrors field.ErrorList
+
+	for loggerIdx, logger := range structuredLoggers {
+		if (logger.Category != "") == (logger.CategoriesFilter != nil) {
+			allErrors = append(allErrors, field.Invalid(
+				parentPath.Child("structuredLoggers").Index(loggerIdx), logger.Name,
+				"exactly one of category and categoriesFilter must be set"))
+		}
+	}
+
+	return allErrors
+}
+
 func requireLocations(
 	locationsPath *field.Path,
 	locations []ytv1.LocationSpec,
@@ -697,6 +711,8 @@ func (r *baseValidator) validateInstanceSpecWithTimbertruck(instanceSpec ytv1.In
 	allErrors = append(allErrors, r.validatePodSpec(&instanceSpec.PodSpec, path)...)
 
 	allErrors = append(allErrors, r.validateTimbertruckSpec(componentTimbertruck, commonSpec.Timbertruck, instanceSpec.StructuredLoggers, instanceSpec.Locations, path)...)
+
+	allErrors = append(allErrors, r.validateStructuredLoggers(instanceSpec.StructuredLoggers, path)...)
 
 	if instanceSpec.EnableAntiAffinity != nil {
 		allErrors = append(allErrors, field.Invalid(path.Child("EnableAntiAffinity"), instanceSpec.EnableAntiAffinity,

--- a/validators/ytsaurus_webhook.go
+++ b/validators/ytsaurus_webhook.go
@@ -414,14 +414,20 @@ func (r *baseValidator) validateTimbertruckSpec(
 	return allErrors
 }
 
-func (r *baseValidator) validateStructuredLoggers(structuredLoggers []ytv1.StructuredLoggerSpec, parentPath *field.Path) field.ErrorList {
+func validateStructuredLoggers(structuredLoggers []ytv1.StructuredLoggerSpec, parentPath *field.Path) field.ErrorList {
 	var allErrors field.ErrorList
 
 	for loggerIdx, logger := range structuredLoggers {
+		loggerPath := parentPath.Child("structuredLoggers").Index(loggerIdx)
+
 		if (logger.Category != "") == (logger.CategoriesFilter != nil) {
-			allErrors = append(allErrors, field.Invalid(
-				parentPath.Child("structuredLoggers").Index(loggerIdx), logger.Name,
+			allErrors = append(allErrors, field.Invalid(loggerPath, logger.Name,
 				"exactly one of category and categoriesFilter must be set"))
+		}
+		// Without both, the rule ends up with no category restriction and matches every category.
+		if filter := logger.CategoriesFilter; filter != nil && (filter.Type == "" || len(filter.Values) == 0) {
+			allErrors = append(allErrors, field.Required(loggerPath.Child("categoriesFilter"),
+				"categoriesFilter requires type and values"))
 		}
 	}
 
@@ -459,6 +465,7 @@ func (r *ytsaurusValidator) validateExtraTimbertruckComponents(newYtsaurus *ytv1
 	validate := func(instanceSpec *ytv1.InstanceSpec, path *field.Path) {
 		allErrors = append(allErrors, r.validateTimbertruckSpec(nil, commonTimbertruck,
 			instanceSpec.StructuredLoggers, instanceSpec.Locations, path)...)
+		allErrors = append(allErrors, validateStructuredLoggers(instanceSpec.StructuredLoggers, path)...)
 	}
 
 	if mc := newYtsaurus.Spec.MasterCaches; mc != nil {
@@ -712,7 +719,7 @@ func (r *baseValidator) validateInstanceSpecWithTimbertruck(instanceSpec ytv1.In
 
 	allErrors = append(allErrors, r.validateTimbertruckSpec(componentTimbertruck, commonSpec.Timbertruck, instanceSpec.StructuredLoggers, instanceSpec.Locations, path)...)
 
-	allErrors = append(allErrors, r.validateStructuredLoggers(instanceSpec.StructuredLoggers, path)...)
+	allErrors = append(allErrors, validateStructuredLoggers(instanceSpec.StructuredLoggers, path)...)
 
 	if instanceSpec.EnableAntiAffinity != nil {
 		allErrors = append(allErrors, field.Invalid(path.Child("EnableAntiAffinity"), instanceSpec.EnableAntiAffinity,

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -1231,8 +1231,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Category filter for logs spanning several categories,
-                        as for text loggers.
+                      description: Filter for logs spanning several categories. Type
+                        must be set.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1248,7 +1248,8 @@ spec:
                           type: array
                       type: object
                     category:
-                      description: Single category to log.
+                      description: Exactly one of category and categoriesFilter must
+                        be set.
                       type: string
                     compression:
                       default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -1231,8 +1231,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Additional include/exclude category filter applied
-                        on top of category.
+                      description: Category filter for logs spanning several categories,
+                        as for text loggers.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1248,6 +1248,7 @@ spec:
                           type: array
                       type: object
                     category:
+                      description: Single category to log.
                       type: string
                     compression:
                       default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_offshoredatagateways.yaml
@@ -1230,6 +1230,23 @@ spec:
               structuredLoggers:
                 items:
                   properties:
+                    categoriesFilter:
+                      description: Additional include/exclude category filter applied
+                        on top of category.
+                      properties:
+                        type:
+                          description: CategoriesFilterType string describes types
+                            of possible log CategoriesFilter.
+                          enum:
+                          - exclude
+                          - include
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
                     category:
                       type: string
                     compression:

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -1235,6 +1235,23 @@ spec:
               structuredLoggers:
                 items:
                   properties:
+                    categoriesFilter:
+                      description: Additional include/exclude category filter applied
+                        on top of category.
+                      properties:
+                        type:
+                          description: CategoriesFilterType string describes types
+                            of possible log CategoriesFilter.
+                          enum:
+                          - exclude
+                          - include
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
                     category:
                       type: string
                     compression:

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -1236,8 +1236,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Additional include/exclude category filter applied
-                        on top of category.
+                      description: Category filter for logs spanning several categories,
+                        as for text loggers.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1253,6 +1253,7 @@ spec:
                           type: array
                       type: object
                     category:
+                      description: Single category to log.
                       type: string
                     compression:
                       default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotedatanodes.yaml
@@ -1236,8 +1236,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Category filter for logs spanning several categories,
-                        as for text loggers.
+                      description: Filter for logs spanning several categories. Type
+                        must be set.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1253,7 +1253,8 @@ spec:
                           type: array
                       type: object
                     category:
-                      description: Single category to log.
+                      description: Exactly one of category and categoriesFilter must
+                        be set.
                       type: string
                     compression:
                       default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -1500,8 +1500,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Category filter for logs spanning several categories,
-                        as for text loggers.
+                      description: Filter for logs spanning several categories. Type
+                        must be set.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1517,7 +1517,8 @@ spec:
                           type: array
                       type: object
                     category:
-                      description: Single category to log.
+                      description: Exactly one of category and categoriesFilter must
+                        be set.
                       type: string
                     compression:
                       default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -1500,8 +1500,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Additional include/exclude category filter applied
-                        on top of category.
+                      description: Category filter for logs spanning several categories,
+                        as for text loggers.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1517,6 +1517,7 @@ spec:
                           type: array
                       type: object
                     category:
+                      description: Single category to log.
                       type: string
                     compression:
                       default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remoteexecnodes.yaml
@@ -1499,6 +1499,23 @@ spec:
               structuredLoggers:
                 items:
                   properties:
+                    categoriesFilter:
+                      description: Additional include/exclude category filter applied
+                        on top of category.
+                      properties:
+                        type:
+                          description: CategoriesFilterType string describes types
+                            of possible log CategoriesFilter.
+                          enum:
+                          - exclude
+                          - include
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
                     category:
                       type: string
                     compression:

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -1235,6 +1235,23 @@ spec:
               structuredLoggers:
                 items:
                   properties:
+                    categoriesFilter:
+                      description: Additional include/exclude category filter applied
+                        on top of category.
+                      properties:
+                        type:
+                          description: CategoriesFilterType string describes types
+                            of possible log CategoriesFilter.
+                          enum:
+                          - exclude
+                          - include
+                          type: string
+                        values:
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                      type: object
                     category:
                       type: string
                     compression:

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -1236,8 +1236,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Additional include/exclude category filter applied
-                        on top of category.
+                      description: Category filter for logs spanning several categories,
+                        as for text loggers.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1253,6 +1253,7 @@ spec:
                           type: array
                       type: object
                     category:
+                      description: Single category to log.
                       type: string
                     compression:
                       default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_remotetabletnodes.yaml
@@ -1236,8 +1236,8 @@ spec:
                 items:
                   properties:
                     categoriesFilter:
-                      description: Category filter for logs spanning several categories,
-                        as for text loggers.
+                      description: Filter for logs spanning several categories. Type
+                        must be set.
                       properties:
                         type:
                           description: CategoriesFilterType string describes types
@@ -1253,7 +1253,8 @@ spec:
                           type: array
                       type: object
                     category:
-                      description: Single category to log.
+                      description: Exactly one of category and categoriesFilter must
+                        be set.
                       type: string
                     compression:
                       default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -1127,8 +1127,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -1144,7 +1144,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -3149,8 +3150,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -3166,7 +3167,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -5047,8 +5049,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -5064,7 +5066,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -6958,8 +6961,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -6975,7 +6978,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -8862,8 +8866,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -8879,7 +8883,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -11080,8 +11085,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -11097,7 +11102,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -13044,8 +13050,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -13061,7 +13067,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -14997,8 +15004,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -15014,7 +15021,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -16912,8 +16920,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -16929,7 +16937,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -18932,8 +18941,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -18949,7 +18958,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -20837,8 +20847,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -20854,7 +20864,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -22731,8 +22742,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -22748,7 +22759,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -24650,8 +24662,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -24667,7 +24679,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -26586,8 +26599,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -26603,7 +26616,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -28526,8 +28540,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -28543,7 +28557,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -30606,8 +30621,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -30623,7 +30638,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none
@@ -32517,8 +32533,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -32534,7 +32550,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -34447,8 +34464,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Category filter for logs spanning several
-                              categories, as for text loggers.
+                            description: Filter for logs spanning several categories.
+                              Type must be set.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -34464,7 +34481,8 @@ spec:
                                 type: array
                             type: object
                           category:
-                            description: Single category to log.
+                            description: Exactly one of category and categoriesFilter
+                              must be set.
                             type: string
                           compression:
                             default: none
@@ -36828,8 +36846,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Category filter for logs spanning several categories,
-                            as for text loggers.
+                          description: Filter for logs spanning several categories.
+                            Type must be set.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -36845,7 +36863,8 @@ spec:
                               type: array
                           type: object
                         category:
-                          description: Single category to log.
+                          description: Exactly one of category and categoriesFilter
+                            must be set.
                           type: string
                         compression:
                           default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -1127,8 +1127,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -1144,6 +1144,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -3148,8 +3149,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -3165,6 +3166,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -5045,8 +5047,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -5062,6 +5064,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -6955,8 +6958,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -6972,6 +6975,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -8858,8 +8862,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -8875,6 +8879,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -11075,8 +11080,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -11092,6 +11097,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -13038,8 +13044,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -13055,6 +13061,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -14990,8 +14997,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -15007,6 +15014,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -16904,8 +16912,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -16921,6 +16929,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -18923,8 +18932,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -18940,6 +18949,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -20827,8 +20837,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -20844,6 +20854,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -22720,8 +22731,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -22737,6 +22748,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -24638,8 +24650,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -24655,6 +24667,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -26573,8 +26586,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -26590,6 +26603,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -28512,8 +28526,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -28529,6 +28543,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -30591,8 +30606,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -30608,6 +30623,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none
@@ -32501,8 +32517,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -32518,6 +32534,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -34430,8 +34447,8 @@ spec:
                       items:
                         properties:
                           categoriesFilter:
-                            description: Additional include/exclude category filter
-                              applied on top of category.
+                            description: Category filter for logs spanning several
+                              categories, as for text loggers.
                             properties:
                               type:
                                 description: CategoriesFilterType string describes
@@ -34447,6 +34464,7 @@ spec:
                                 type: array
                             type: object
                           category:
+                            description: Single category to log.
                             type: string
                           compression:
                             default: none
@@ -36810,8 +36828,8 @@ spec:
                     items:
                       properties:
                         categoriesFilter:
-                          description: Additional include/exclude category filter
-                            applied on top of category.
+                          description: Category filter for logs spanning several categories,
+                            as for text loggers.
                           properties:
                             type:
                               description: CategoriesFilterType string describes types
@@ -36827,6 +36845,7 @@ spec:
                               type: array
                           type: object
                         category:
+                          description: Single category to log.
                           type: string
                         compression:
                           default: none

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -1126,6 +1126,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -3130,6 +3147,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -5010,6 +5044,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -6903,6 +6954,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -8789,6 +8857,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -10989,6 +11074,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -12935,6 +13037,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -14870,6 +14989,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -16767,6 +16903,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -18769,6 +18922,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -20656,6 +20826,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -22532,6 +22719,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -24433,6 +24637,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -26351,6 +26572,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -28273,6 +28511,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -30335,6 +30590,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:
@@ -32228,6 +32500,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -34140,6 +34429,23 @@ spec:
                     structuredLoggers:
                       items:
                         properties:
+                          categoriesFilter:
+                            description: Additional include/exclude category filter
+                              applied on top of category.
+                            properties:
+                              type:
+                                description: CategoriesFilterType string describes
+                                  types of possible log CategoriesFilter.
+                                enum:
+                                - exclude
+                                - include
+                                type: string
+                              values:
+                                items:
+                                  type: string
+                                minItems: 1
+                                type: array
+                            type: object
                           category:
                             type: string
                           compression:
@@ -36503,6 +36809,23 @@ spec:
                   structuredLoggers:
                     items:
                       properties:
+                        categoriesFilter:
+                          description: Additional include/exclude category filter
+                            applied on top of category.
+                          properties:
+                            type:
+                              description: CategoriesFilterType string describes types
+                                of possible log CategoriesFilter.
+                              enum:
+                              - exclude
+                              - include
+                              type: string
+                            values:
+                              items:
+                                type: string
+                              minItems: 1
+                              type: array
+                          type: object
                         category:
                           type: string
                         compression:


### PR DESCRIPTION
Needed to deliver the scheduler event log: it is yson and spans two categories.

- Structured loggers with `format: yson` now go to timbertruck's `yson_logs` section. They were emitted as `json_logs`, whose validator dropped every line — delivery looked healthy while nothing arrived. Requires a timbertruck image that understands `yson_logs`.
- A structured logger can select several categories via `categoriesFilter`. It replaces `category` rather than extending it: a webhook requires exactly one of the two, and rejects a filter with no type or values, which would otherwise leave the rule matching every category. `category` keeps working and was already optional in the schema, so existing specs are untouched.

A `format: plain_text` structured logger still goes to `json_logs` — pre-existing, left as is.
