### PR TITLE
Postprocess the timbertruck sidecar config

### DIFF
--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -113,7 +113,7 @@ func newServer(
 		delivery = resolveTimbertruckDelivery(opts.timbertruck, ytsaurus.GetCommonSpec().Timbertruck, instanceSpec)
 		if delivery != nil {
 			var err error
-			volumeMounts, err = buildTimbertruckVolumeMounts(instanceSpec, timbertruckConfigVolumeName)
+			volumeMounts, err = buildTimbertruckVolumeMounts(instanceSpec)
 			if err != nil {
 				log.Log.Error(err, "Timbertruck log delivery is disabled for component",
 					"component", l.GetFullComponentName())
@@ -583,7 +583,9 @@ func (s *serverImpl) rebuildStatefulSet() *appsv1.StatefulSet {
 	}
 	filename := s.configs.generators[0].FileName
 
-	configPostprocessingCommand := getConfigPostprocessingCommand(filename)
+	configPostprocessingCommand := getConfigPostprocessingCommand(
+		path.Join(consts.ConfigMountPoint, consts.PostprocessConfigScriptName),
+		path.Join(consts.ConfigTemplateMountPoint, filename))
 
 	var readinessProbeParams ytv1.HealthcheckProbeParams
 	if s.instanceSpec.ReadinessProbeParams != nil {

--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -593,9 +593,7 @@ func (s *serverImpl) rebuildStatefulSet() *appsv1.StatefulSet {
 		postprocessVolumeMounts = append(slices.Clone(volumeMounts), timbertruckConfigTemplateVolumeMount())
 	}
 
-	configPostprocessingCommand := getConfigPostprocessingCommand(
-		path.Join(consts.ConfigMountPoint, consts.PostprocessConfigScriptName),
-		configTemplatePaths...)
+	configPostprocessingCommand := getConfigPostprocessingCommand(configTemplatePaths...)
 
 	var readinessProbeParams ytv1.HealthcheckProbeParams
 	if s.instanceSpec.ReadinessProbeParams != nil {

--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -584,9 +584,7 @@ func (s *serverImpl) rebuildStatefulSet() *appsv1.StatefulSet {
 	}
 	filename := s.configs.generators[0].FileName
 
-	configPostprocessingCommand := getConfigPostprocessingCommand(
-		consts.PostprocessConfigScriptName,
-		path.Join(consts.ConfigTemplateMountPoint, filename))
+	configPostprocessingCommand := getConfigPostprocessingCommand(consts.PostprocessConfigScriptName, path.Join(consts.ConfigTemplateMountPoint, filename))
 
 	postprocessVolumeMounts := volumeMounts
 	if s.timbertruckDelivery != nil {

--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 	"path"
+	"slices"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -583,9 +584,18 @@ func (s *serverImpl) rebuildStatefulSet() *appsv1.StatefulSet {
 	}
 	filename := s.configs.generators[0].FileName
 
+	// The sidecar config goes through the same postprocessing, so that it can use the same placeholders.
+	configTemplatePaths := []string{path.Join(consts.ConfigTemplateMountPoint, filename)}
+	postprocessVolumeMounts := volumeMounts
+	if s.timbertruckDelivery != nil {
+		configTemplatePaths = append(configTemplatePaths,
+			path.Join(consts.TimbertruckConfigMountPoint, timbertruckConfigFileName(s.labeller)))
+		postprocessVolumeMounts = append(slices.Clone(volumeMounts), timbertruckConfigTemplateVolumeMount())
+	}
+
 	configPostprocessingCommand := getConfigPostprocessingCommand(
 		path.Join(consts.ConfigMountPoint, consts.PostprocessConfigScriptName),
-		path.Join(consts.ConfigTemplateMountPoint, filename))
+		configTemplatePaths...)
 
 	var readinessProbeParams ytv1.HealthcheckProbeParams
 	if s.instanceSpec.ReadinessProbeParams != nil {
@@ -642,7 +652,7 @@ func (s *serverImpl) rebuildStatefulSet() *appsv1.StatefulSet {
 				Name:         consts.PostprocessConfigContainerName,
 				Command:      []string{"bash", "-xc", configPostprocessingCommand},
 				Env:          getDefaultEnv(),
-				VolumeMounts: volumeMounts,
+				VolumeMounts: postprocessVolumeMounts,
 			},
 		},
 		Volumes:      volumes,

--- a/pkg/components/server.go
+++ b/pkg/components/server.go
@@ -584,16 +584,15 @@ func (s *serverImpl) rebuildStatefulSet() *appsv1.StatefulSet {
 	}
 	filename := s.configs.generators[0].FileName
 
-	// The sidecar config goes through the same postprocessing, so that it can use the same placeholders.
-	configTemplatePaths := []string{path.Join(consts.ConfigTemplateMountPoint, filename)}
+	configPostprocessingCommand := getConfigPostprocessingCommand(
+		consts.PostprocessConfigScriptName,
+		path.Join(consts.ConfigTemplateMountPoint, filename))
+
 	postprocessVolumeMounts := volumeMounts
 	if s.timbertruckDelivery != nil {
-		configTemplatePaths = append(configTemplatePaths,
-			path.Join(consts.TimbertruckConfigMountPoint, timbertruckConfigFileName(s.labeller)))
+		configPostprocessingCommand += timbertruckConfigPostprocessingCommand(s.labeller)
 		postprocessVolumeMounts = append(slices.Clone(volumeMounts), timbertruckConfigTemplateVolumeMount())
 	}
-
-	configPostprocessingCommand := getConfigPostprocessingCommand(configTemplatePaths...)
 
 	var readinessProbeParams ytv1.HealthcheckProbeParams
 	if s.instanceSpec.ReadinessProbeParams != nil {

--- a/pkg/components/timbertruck.go
+++ b/pkg/components/timbertruck.go
@@ -330,8 +330,8 @@ func timbertruckComponentName(l *labeller.Labeller) string {
 // It must be unique per component (it includes the full component label, e.g.
 // "yt-master-timbertruck.yaml") so that config overrides, which are keyed by file name, can
 // target a specific component's timbertruck config instead of colliding across all of them.
-// The same name is the configmap data key and the file the sidecar reads, passed via -config
-// (the postprocessed copy under consts.ConfigMountPoint).
+// The same name is the configmap data key and the file the sidecar reads (postprocessed into
+// consts.ConfigMountPoint and passed via -config).
 func timbertruckConfigFileName(l *labeller.Labeller) string {
 	return fmt.Sprintf("%s-timbertruck.yaml", l.GetFullComponentLabel())
 }
@@ -614,21 +614,18 @@ func buildTimbertruckConfigMap(
 	)
 }
 
-const (
-	// timbertruckConfigVolumeName is the pod volume holding the sidecar's config.
-	timbertruckConfigVolumeName = consts.TimbertruckContainerName + "-config"
-	// timbertruckPostprocessConfigScriptName is kept apart from the server's one, since both scripts
-	// are written into the shared config volume.
-	timbertruckPostprocessConfigScriptName = "postprocess-timbertruck-config.sh"
-)
+// timbertruckConfigVolumeName is the pod volume holding the sidecar's config.
+const timbertruckConfigVolumeName = consts.TimbertruckContainerName + "-config"
+
+// timbertruckPostprocessConfigScriptName is kept apart from the server's one, since both scripts
+// are written into the shared config volume.
+const timbertruckPostprocessConfigScriptName = "postprocess-timbertruck-config.sh"
 
 // timbertruckConfigPostprocessingCommand postprocesses the sidecar config the same way the server
 // config is postprocessed. The init container runs it once, and the sidecar runs it again on every
 // start, so that a configmap re-sync reaches a running pod without recreating it.
 func timbertruckConfigPostprocessingCommand(l *labeller.Labeller) string {
-	return getConfigPostprocessingCommand(
-		timbertruckPostprocessConfigScriptName,
-		path.Join(consts.TimbertruckConfigMountPoint, timbertruckConfigFileName(l)))
+	return getConfigPostprocessingCommand(timbertruckPostprocessConfigScriptName, path.Join(consts.TimbertruckConfigMountPoint, timbertruckConfigFileName(l)))
 }
 
 // addTimbertruckSidecar appends the timbertruck sidecar container and its config volume to podSpec.
@@ -637,12 +634,13 @@ func timbertruckConfigPostprocessingCommand(l *labeller.Labeller) string {
 func addTimbertruckSidecar(podSpec *corev1.PodSpec, image string, volumeMounts []corev1.VolumeMount, configMapName, configFileName string) {
 	podSpec.Volumes = append(podSpec.Volumes, createConfigVolume(timbertruckConfigVolumeName, configMapName, nil))
 
+	postprocessScriptPath := path.Join(consts.ConfigMountPoint, timbertruckPostprocessConfigScriptName)
+	configPath := path.Join(consts.ConfigMountPoint, configFileName)
+
 	podSpec.Containers = append(podSpec.Containers, corev1.Container{
-		Name:  consts.TimbertruckContainerName,
-		Image: image,
-		Command: []string{"bash", "-c", fmt.Sprintf("source %v; exec /usr/bin/timbertruck_os -config %v",
-			path.Join(consts.ConfigMountPoint, timbertruckPostprocessConfigScriptName),
-			path.Join(consts.ConfigMountPoint, configFileName))},
+		Name:    consts.TimbertruckContainerName,
+		Image:   image,
+		Command: []string{"bash", "-c", fmt.Sprintf("source %v; exec /usr/bin/timbertruck_os -config %v", postprocessScriptPath, configPath)},
 		Env: append([]corev1.EnvVar{
 			{
 				Name: consts.TokenSecretKey,

--- a/pkg/components/timbertruck.go
+++ b/pkg/components/timbertruck.go
@@ -615,12 +615,7 @@ func buildTimbertruckConfigMap(
 }
 
 // timbertruckConfigVolumeName is the pod volume holding the sidecar's config.
-const (
-	timbertruckConfigVolumeName = consts.TimbertruckContainerName + "-config"
-	// timbertruckPostprocessConfigScriptName is kept apart from the server's script of the same purpose,
-	// since both are written into the shared config volume.
-	timbertruckPostprocessConfigScriptName = "postprocess-timbertruck-config.sh"
-)
+const timbertruckConfigVolumeName = consts.TimbertruckContainerName + "-config"
 
 // addTimbertruckSidecar appends the timbertruck sidecar container and its config volume to podSpec.
 // volumeMounts are resolved beforehand by buildTimbertruckVolumeMounts, so the sidecar sees the very
@@ -628,18 +623,10 @@ const (
 func addTimbertruckSidecar(podSpec *corev1.PodSpec, image string, volumeMounts []corev1.VolumeMount, configMapName, configFileName string) {
 	podSpec.Volumes = append(podSpec.Volumes, createConfigVolume(timbertruckConfigVolumeName, configMapName, nil))
 
-	// The config is postprocessed on every container start rather than once by the init container,
-	// so that a configmap re-sync still reaches a running pod, as it did when the sidecar read the
-	// configmap directly.
-	configPath := path.Join(consts.ConfigMountPoint, configFileName)
-	postprocessingCommand := getConfigPostprocessingCommand(
-		path.Join(consts.ConfigMountPoint, timbertruckPostprocessConfigScriptName),
-		path.Join(consts.TimbertruckConfigMountPoint, configFileName))
-
 	podSpec.Containers = append(podSpec.Containers, corev1.Container{
 		Name:    consts.TimbertruckContainerName,
 		Image:   image,
-		Command: []string{"bash", "-xc", fmt.Sprintf("%v exec /usr/bin/timbertruck_os -config %v", postprocessingCommand, configPath)},
+		Command: []string{"/usr/bin/timbertruck_os", "-config", path.Join(consts.ConfigMountPoint, configFileName)},
 		Env: append([]corev1.EnvVar{
 			{
 				Name: consts.TokenSecretKey,
@@ -658,19 +645,22 @@ func addTimbertruckSidecar(podSpec *corev1.PodSpec, image string, volumeMounts [
 	})
 }
 
+// timbertruckConfigTemplateVolumeMount is the sidecar's raw config, mounted into the postprocessing
+// init container. The sidecar itself reads the postprocessed copy from consts.ConfigMountPoint.
+func timbertruckConfigTemplateVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      timbertruckConfigVolumeName,
+		MountPath: consts.TimbertruckConfigMountPoint,
+		ReadOnly:  true,
+	}
+}
+
 // buildTimbertruckVolumeMounts resolves the spec-derived log volume mount for the timbertruck
-// sidecar, the read-only mount of its raw config and the volume its postprocessed copy is written to.
+// sidecar and appends the volume holding its postprocessed config.
 func buildTimbertruckVolumeMounts(instanceSpec *ytv1.InstanceSpec) ([]corev1.VolumeMount, error) {
 	logMounts, err := resolveLocationMounts(instanceSpec, ytv1.LocationTypeLogs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve mounts for timbertruck: %w", err)
 	}
-	return append(logMounts,
-		corev1.VolumeMount{
-			Name:      timbertruckConfigVolumeName,
-			MountPath: consts.TimbertruckConfigMountPoint,
-			ReadOnly:  true,
-		},
-		createConfigVolumeMount(),
-	), nil
+	return append(logMounts, createConfigVolumeMount()), nil
 }

--- a/pkg/components/timbertruck.go
+++ b/pkg/components/timbertruck.go
@@ -330,8 +330,8 @@ func timbertruckComponentName(l *labeller.Labeller) string {
 // It must be unique per component (it includes the full component label, e.g.
 // "yt-master-timbertruck.yaml") so that config overrides, which are keyed by file name, can
 // target a specific component's timbertruck config instead of colliding across all of them.
-// The same name is the configmap data key and the file the sidecar reads (mounted under
-// consts.TimbertruckConfigMountPoint and passed via -config).
+// The same name is the configmap data key and the file the sidecar reads, passed via -config
+// (the postprocessed copy under consts.ConfigMountPoint).
 func timbertruckConfigFileName(l *labeller.Labeller) string {
 	return fmt.Sprintf("%s-timbertruck.yaml", l.GetFullComponentLabel())
 }
@@ -615,7 +615,12 @@ func buildTimbertruckConfigMap(
 }
 
 // timbertruckConfigVolumeName is the pod volume holding the sidecar's config.
-const timbertruckConfigVolumeName = consts.TimbertruckContainerName + "-config"
+const (
+	timbertruckConfigVolumeName = consts.TimbertruckContainerName + "-config"
+	// timbertruckPostprocessConfigScriptName is kept apart from the server's script of the same purpose,
+	// since both are written into the shared config volume.
+	timbertruckPostprocessConfigScriptName = "postprocess-timbertruck-config.sh"
+)
 
 // addTimbertruckSidecar appends the timbertruck sidecar container and its config volume to podSpec.
 // volumeMounts are resolved beforehand by buildTimbertruckVolumeMounts, so the sidecar sees the very
@@ -623,10 +628,18 @@ const timbertruckConfigVolumeName = consts.TimbertruckContainerName + "-config"
 func addTimbertruckSidecar(podSpec *corev1.PodSpec, image string, volumeMounts []corev1.VolumeMount, configMapName, configFileName string) {
 	podSpec.Volumes = append(podSpec.Volumes, createConfigVolume(timbertruckConfigVolumeName, configMapName, nil))
 
+	// The config is postprocessed on every container start rather than once by the init container,
+	// so that a configmap re-sync still reaches a running pod, as it did when the sidecar read the
+	// configmap directly.
+	configPath := path.Join(consts.ConfigMountPoint, configFileName)
+	postprocessingCommand := getConfigPostprocessingCommand(
+		path.Join(consts.ConfigMountPoint, timbertruckPostprocessConfigScriptName),
+		path.Join(consts.TimbertruckConfigMountPoint, configFileName))
+
 	podSpec.Containers = append(podSpec.Containers, corev1.Container{
 		Name:    consts.TimbertruckContainerName,
 		Image:   image,
-		Command: []string{"/usr/bin/timbertruck_os", "-config", path.Join(consts.TimbertruckConfigMountPoint, configFileName)},
+		Command: []string{"bash", "-xc", fmt.Sprintf("%v exec /usr/bin/timbertruck_os -config %v", postprocessingCommand, configPath)},
 		Env: append([]corev1.EnvVar{
 			{
 				Name: consts.TokenSecretKey,
@@ -645,16 +658,19 @@ func addTimbertruckSidecar(podSpec *corev1.PodSpec, image string, volumeMounts [
 	})
 }
 
-// buildTimbertruckVolumeMounts resolves the spec-derived log volume mount for
-// the timbertruck sidecar and appends the read-only mount for its config.
-func buildTimbertruckVolumeMounts(instanceSpec *ytv1.InstanceSpec, configVolumeName string) ([]corev1.VolumeMount, error) {
+// buildTimbertruckVolumeMounts resolves the spec-derived log volume mount for the timbertruck
+// sidecar, the read-only mount of its raw config and the volume its postprocessed copy is written to.
+func buildTimbertruckVolumeMounts(instanceSpec *ytv1.InstanceSpec) ([]corev1.VolumeMount, error) {
 	logMounts, err := resolveLocationMounts(instanceSpec, ytv1.LocationTypeLogs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve mounts for timbertruck: %w", err)
 	}
-	return append(logMounts, corev1.VolumeMount{
-		Name:      configVolumeName,
-		MountPath: consts.TimbertruckConfigMountPoint,
-		ReadOnly:  true,
-	}), nil
+	return append(logMounts,
+		corev1.VolumeMount{
+			Name:      timbertruckConfigVolumeName,
+			MountPath: consts.TimbertruckConfigMountPoint,
+			ReadOnly:  true,
+		},
+		createConfigVolumeMount(),
+	), nil
 }

--- a/pkg/components/timbertruck.go
+++ b/pkg/components/timbertruck.go
@@ -614,8 +614,22 @@ func buildTimbertruckConfigMap(
 	)
 }
 
-// timbertruckConfigVolumeName is the pod volume holding the sidecar's config.
-const timbertruckConfigVolumeName = consts.TimbertruckContainerName + "-config"
+const (
+	// timbertruckConfigVolumeName is the pod volume holding the sidecar's config.
+	timbertruckConfigVolumeName = consts.TimbertruckContainerName + "-config"
+	// timbertruckPostprocessConfigScriptName is kept apart from the server's one, since both scripts
+	// are written into the shared config volume.
+	timbertruckPostprocessConfigScriptName = "postprocess-timbertruck-config.sh"
+)
+
+// timbertruckConfigPostprocessingCommand postprocesses the sidecar config the same way the server
+// config is postprocessed. The init container runs it once, and the sidecar runs it again on every
+// start, so that a configmap re-sync reaches a running pod without recreating it.
+func timbertruckConfigPostprocessingCommand(l *labeller.Labeller) string {
+	return getConfigPostprocessingCommand(
+		timbertruckPostprocessConfigScriptName,
+		path.Join(consts.TimbertruckConfigMountPoint, timbertruckConfigFileName(l)))
+}
 
 // addTimbertruckSidecar appends the timbertruck sidecar container and its config volume to podSpec.
 // volumeMounts are resolved beforehand by buildTimbertruckVolumeMounts, so the sidecar sees the very
@@ -624,9 +638,11 @@ func addTimbertruckSidecar(podSpec *corev1.PodSpec, image string, volumeMounts [
 	podSpec.Volumes = append(podSpec.Volumes, createConfigVolume(timbertruckConfigVolumeName, configMapName, nil))
 
 	podSpec.Containers = append(podSpec.Containers, corev1.Container{
-		Name:    consts.TimbertruckContainerName,
-		Image:   image,
-		Command: []string{"/usr/bin/timbertruck_os", "-config", path.Join(consts.ConfigMountPoint, configFileName)},
+		Name:  consts.TimbertruckContainerName,
+		Image: image,
+		Command: []string{"bash", "-c", fmt.Sprintf("source %v; exec /usr/bin/timbertruck_os -config %v",
+			path.Join(consts.ConfigMountPoint, timbertruckPostprocessConfigScriptName),
+			path.Join(consts.ConfigMountPoint, configFileName))},
 		Env: append([]corev1.EnvVar{
 			{
 				Name: consts.TokenSecretKey,
@@ -656,11 +672,11 @@ func timbertruckConfigTemplateVolumeMount() corev1.VolumeMount {
 }
 
 // buildTimbertruckVolumeMounts resolves the spec-derived log volume mount for the timbertruck
-// sidecar and appends the volume holding its postprocessed config.
+// sidecar, the configmap holding its raw config and the volume its postprocessed copy is written to.
 func buildTimbertruckVolumeMounts(instanceSpec *ytv1.InstanceSpec) ([]corev1.VolumeMount, error) {
 	logMounts, err := resolveLocationMounts(instanceSpec, ytv1.LocationTypeLogs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve mounts for timbertruck: %w", err)
 	}
-	return append(logMounts, createConfigVolumeMount()), nil
+	return append(logMounts, timbertruckConfigTemplateVolumeMount(), createConfigVolumeMount()), nil
 }

--- a/pkg/components/timbertruck_test.go
+++ b/pkg/components/timbertruck_test.go
@@ -102,20 +102,16 @@ var _ = Describe("buildTimbertruckVolumeMounts", func() {
 
 		mounts, err := buildTimbertruckVolumeMounts(instanceSpec)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(mounts).To(HaveLen(3))
+		Expect(mounts).To(HaveLen(2))
 
 		Expect(mounts[0].Name).To(Equal("logs-vol"))
 		Expect(mounts[0].MountPath).To(Equal("/yt/logs/master-logs/logs"))
 		Expect(mounts[0].SubPath).To(Equal("master-logs/logs"))
 		Expect(mounts[0].ReadOnly).To(BeFalseBecause("timbertruck must be able to write to logs location"))
 
-		Expect(mounts[1].Name).To(Equal(timbertruckConfigVolumeName))
-		Expect(mounts[1].MountPath).To(Equal(consts.TimbertruckConfigMountPoint))
-		Expect(mounts[1].ReadOnly).To(BeTrueBecause("the raw config is only read from"))
-
-		Expect(mounts[2].Name).To(Equal(consts.ConfigVolumeName))
-		Expect(mounts[2].MountPath).To(Equal(consts.ConfigMountPoint))
-		Expect(mounts[2].ReadOnly).To(BeFalseBecause("the postprocessed config is written into this volume"))
+		Expect(mounts[1].Name).To(Equal(consts.ConfigVolumeName))
+		Expect(mounts[1].MountPath).To(Equal(consts.ConfigMountPoint))
+		Expect(mounts[1].ReadOnly).To(BeFalseBecause("the postprocessed config is written into this volume"))
 	})
 
 	It("errors when no logs location is defined", func() {

--- a/pkg/components/timbertruck_test.go
+++ b/pkg/components/timbertruck_test.go
@@ -89,9 +89,7 @@ func TestTimbertruckInstanceGroupsShareDeliveryQueue(t *testing.T) {
 }
 
 var _ = Describe("buildTimbertruckVolumeMounts", func() {
-	const configVolumeName = consts.TimbertruckContainerName + "-config"
-
-	It("derives the log mount from the instance spec and mounts the config read-only", func() {
+	It("derives the log mount from the instance spec and mounts the postprocessed config volume", func() {
 		instanceSpec := &v1.InstanceSpec{
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: "data-vol", MountPath: "/yt/data"},
@@ -102,18 +100,22 @@ var _ = Describe("buildTimbertruckVolumeMounts", func() {
 			},
 		}
 
-		mounts, err := buildTimbertruckVolumeMounts(instanceSpec, configVolumeName)
+		mounts, err := buildTimbertruckVolumeMounts(instanceSpec)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(mounts).To(HaveLen(2))
+		Expect(mounts).To(HaveLen(3))
 
 		Expect(mounts[0].Name).To(Equal("logs-vol"))
 		Expect(mounts[0].MountPath).To(Equal("/yt/logs/master-logs/logs"))
 		Expect(mounts[0].SubPath).To(Equal("master-logs/logs"))
 		Expect(mounts[0].ReadOnly).To(BeFalseBecause("timbertruck must be able to write to logs location"))
 
-		Expect(mounts[1].Name).To(Equal(configVolumeName))
-		Expect(mounts[1].MountPath).To(Equal("/etc/timbertruck"))
-		Expect(mounts[1].ReadOnly).To(BeTrueBecause("timbertruck config must be mounted read-only"))
+		Expect(mounts[1].Name).To(Equal(timbertruckConfigVolumeName))
+		Expect(mounts[1].MountPath).To(Equal(consts.TimbertruckConfigMountPoint))
+		Expect(mounts[1].ReadOnly).To(BeTrueBecause("the raw config is only read from"))
+
+		Expect(mounts[2].Name).To(Equal(consts.ConfigVolumeName))
+		Expect(mounts[2].MountPath).To(Equal(consts.ConfigMountPoint))
+		Expect(mounts[2].ReadOnly).To(BeFalseBecause("the postprocessed config is written into this volume"))
 	})
 
 	It("errors when no logs location is defined", func() {
@@ -122,7 +124,7 @@ var _ = Describe("buildTimbertruckVolumeMounts", func() {
 				{Name: "logs-vol", MountPath: "/yt/logs"},
 			},
 		}
-		_, err := buildTimbertruckVolumeMounts(instanceSpec, configVolumeName)
+		_, err := buildTimbertruckVolumeMounts(instanceSpec)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to resolve mounts"))
 	})
@@ -136,7 +138,7 @@ var _ = Describe("buildTimbertruckVolumeMounts", func() {
 				{LocationType: v1.LocationTypeLogs, Path: "/yt/logs-wrong/master-logs/logs"},
 			},
 		}
-		_, err := buildTimbertruckVolumeMounts(instanceSpec, configVolumeName)
+		_, err := buildTimbertruckVolumeMounts(instanceSpec)
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to resolve mounts"))
 	})

--- a/pkg/components/timbertruck_test.go
+++ b/pkg/components/timbertruck_test.go
@@ -102,16 +102,20 @@ var _ = Describe("buildTimbertruckVolumeMounts", func() {
 
 		mounts, err := buildTimbertruckVolumeMounts(instanceSpec)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(mounts).To(HaveLen(2))
+		Expect(mounts).To(HaveLen(3))
 
 		Expect(mounts[0].Name).To(Equal("logs-vol"))
 		Expect(mounts[0].MountPath).To(Equal("/yt/logs/master-logs/logs"))
 		Expect(mounts[0].SubPath).To(Equal("master-logs/logs"))
 		Expect(mounts[0].ReadOnly).To(BeFalseBecause("timbertruck must be able to write to logs location"))
 
-		Expect(mounts[1].Name).To(Equal(consts.ConfigVolumeName))
-		Expect(mounts[1].MountPath).To(Equal(consts.ConfigMountPoint))
-		Expect(mounts[1].ReadOnly).To(BeFalseBecause("the postprocessed config is written into this volume"))
+		Expect(mounts[1].Name).To(Equal(timbertruckConfigVolumeName))
+		Expect(mounts[1].MountPath).To(Equal(consts.TimbertruckConfigMountPoint))
+		Expect(mounts[1].ReadOnly).To(BeTrueBecause("the raw config is only read from"))
+
+		Expect(mounts[2].Name).To(Equal(consts.ConfigVolumeName))
+		Expect(mounts[2].MountPath).To(Equal(consts.ConfigMountPoint))
+		Expect(mounts[2].ReadOnly).To(BeFalseBecause("the postprocessed config is written into this volume"))
 	})
 
 	It("errors when no logs location is defined", func() {

--- a/pkg/components/timbertruck_test.go
+++ b/pkg/components/timbertruck_test.go
@@ -89,7 +89,9 @@ func TestTimbertruckInstanceGroupsShareDeliveryQueue(t *testing.T) {
 }
 
 var _ = Describe("buildTimbertruckVolumeMounts", func() {
-	It("derives the log mount from the instance spec and mounts the postprocessed config volume", func() {
+	const configVolumeName = consts.TimbertruckContainerName + "-config"
+
+	It("derives the log mount from the instance spec and mounts both config volumes", func() {
 		instanceSpec := &v1.InstanceSpec{
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: "data-vol", MountPath: "/yt/data"},
@@ -109,9 +111,9 @@ var _ = Describe("buildTimbertruckVolumeMounts", func() {
 		Expect(mounts[0].SubPath).To(Equal("master-logs/logs"))
 		Expect(mounts[0].ReadOnly).To(BeFalseBecause("timbertruck must be able to write to logs location"))
 
-		Expect(mounts[1].Name).To(Equal(timbertruckConfigVolumeName))
-		Expect(mounts[1].MountPath).To(Equal(consts.TimbertruckConfigMountPoint))
-		Expect(mounts[1].ReadOnly).To(BeTrueBecause("the raw config is only read from"))
+		Expect(mounts[1].Name).To(Equal(configVolumeName))
+		Expect(mounts[1].MountPath).To(Equal("/etc/timbertruck"))
+		Expect(mounts[1].ReadOnly).To(BeTrueBecause("timbertruck config must be mounted read-only"))
 
 		Expect(mounts[2].Name).To(Equal(consts.ConfigVolumeName))
 		Expect(mounts[2].MountPath).To(Equal(consts.ConfigMountPoint))

--- a/pkg/components/volume.go
+++ b/pkg/components/volume.go
@@ -199,12 +199,14 @@ func getLocationInitCommand(locations []ytv1.LocationSpec) string {
 	return command.String()
 }
 
-func getConfigPostprocessingCommand(postprocessScriptPath string, configTemplatePaths ...string) string {
+func getConfigPostprocessingCommand(configTemplatePaths ...string) string {
 	var command strings.Builder
 
 	// Store postprocessing as a script on filesystem to ease up manual
 	// config re-initialization without pod recreation. This will be useful
 	// when operator starts restarting processes without container recreation.
+
+	postprocessScriptPath := path.Join(consts.ConfigMountPoint, consts.PostprocessConfigScriptName)
 
 	var postprocessScript strings.Builder
 
@@ -218,11 +220,9 @@ func getConfigPostprocessingCommand(postprocessScriptPath string, configTemplate
 		fmt.Fprintf(&postprocessScript, "sed -i -s \"s/{%v}/$(%v)/g\" %v; ", placeholder, command, configPath)
 	}
 
-	configPaths := make([]string, 0, len(configTemplatePaths))
 	for _, configTemplatePath := range configTemplatePaths {
 		configFileName := path.Base(configTemplatePath)
 		configPath := path.Join(consts.ConfigMountPoint, configFileName)
-		configPaths = append(configPaths, configPath)
 
 		fmt.Fprintf(&command, "echo 'Postprocess config %v';", configFileName)
 		fmt.Fprintf(&postprocessScript, "cp %v %v; ", configTemplatePath, configPath)
@@ -238,8 +238,8 @@ func getConfigPostprocessingCommand(postprocessScriptPath string, configTemplate
 	fmt.Fprintf(&command, "echo '%v' > %v; ", postprocessScript.String(), postprocessScriptPath)
 	fmt.Fprintf(&command, "chmod +x '%v'; ", postprocessScriptPath)
 	fmt.Fprintf(&command, "source %v; ", postprocessScriptPath)
-	for _, configPath := range configPaths {
-		fmt.Fprintf(&command, "cat %v; ", configPath)
+	for _, configTemplatePath := range configTemplatePaths {
+		fmt.Fprintf(&command, "cat %v; ", path.Join(consts.ConfigMountPoint, path.Base(configTemplatePath)))
 	}
 
 	return command.String()

--- a/pkg/components/volume.go
+++ b/pkg/components/volume.go
@@ -202,11 +202,13 @@ func getLocationInitCommand(locations []ytv1.LocationSpec) string {
 func getConfigPostprocessingCommand(postprocessScriptName, configTemplatePath string) string {
 	var command strings.Builder
 
+	configFileName := path.Base(configTemplatePath)
+	fmt.Fprintf(&command, "echo 'Postprocess config %v';", configFileName)
+
 	// Store postprocessing as a script on filesystem to ease up manual
 	// config re-initialization without pod recreation. This will be useful
 	// when operator starts restarting processes without container recreation.
 
-	configFileName := path.Base(configTemplatePath)
 	configPath := path.Join(consts.ConfigMountPoint, configFileName)
 	postprocessScriptPath := path.Join(consts.ConfigMountPoint, postprocessScriptName)
 
@@ -217,12 +219,11 @@ func getConfigPostprocessingCommand(postprocessScriptName, configTemplatePath st
 		fmt.Fprintf(&postprocessScript, "sed -i -s \"s/{%v}/${%v}/g\" %v; ", envVar, envVar, configPath)
 	}
 
-	substitutePlaceholderWithCommand := func(placeholder, command string) {
+	substitutePlaceholderWithCommand := func(placeholder string, command string) {
 		// Replace placeholder {placeholder} with the output of the given command.
 		fmt.Fprintf(&postprocessScript, "sed -i -s \"s/{%v}/$(%v)/g\" %v; ", placeholder, command, configPath)
 	}
 
-	fmt.Fprintf(&command, "echo 'Postprocess config %v';", configFileName)
 	fmt.Fprintf(&postprocessScript, "cp %v %v; ", configTemplatePath, configPath)
 
 	for _, envVar := range getDefaultEnv() {

--- a/pkg/components/volume.go
+++ b/pkg/components/volume.go
@@ -199,44 +199,48 @@ func getLocationInitCommand(locations []ytv1.LocationSpec) string {
 	return command.String()
 }
 
-func getConfigPostprocessingCommand(configFileName string) string {
+func getConfigPostprocessingCommand(postprocessScriptPath string, configTemplatePaths ...string) string {
 	var command strings.Builder
-
-	fmt.Fprintf(&command, "echo 'Postprocess config %v';", configFileName)
 
 	// Store postprocessing as a script on filesystem to ease up manual
 	// config re-initialization without pod recreation. This will be useful
 	// when operator starts restarting processes without container recreation.
 
-	configTemplatePath := path.Join(consts.ConfigTemplateMountPoint, configFileName)
-	configPath := path.Join(consts.ConfigMountPoint, configFileName)
-	postprocessScriptPath := path.Join(consts.ConfigMountPoint, consts.PostprocessConfigScriptName)
-
 	var postprocessScript strings.Builder
 
-	substituteEnvCommand := func(envVar string) {
+	substituteEnvCommand := func(configPath, envVar string) {
 		// Replace placeholder {envVar} with the actual value of environment variable envVar.
 		fmt.Fprintf(&postprocessScript, "sed -i -s \"s/{%v}/${%v}/g\" %v; ", envVar, envVar, configPath)
 	}
 
-	substitutePlaceholderWithCommand := func(placeholder string, command string) {
+	substitutePlaceholderWithCommand := func(configPath, placeholder, command string) {
 		// Replace placeholder {placeholder} with the output of the given command.
 		fmt.Fprintf(&postprocessScript, "sed -i -s \"s/{%v}/$(%v)/g\" %v; ", placeholder, command, configPath)
 	}
 
-	fmt.Fprintf(&postprocessScript, "cp %v %v; ", configTemplatePath, configPath)
+	configPaths := make([]string, 0, len(configTemplatePaths))
+	for _, configTemplatePath := range configTemplatePaths {
+		configFileName := path.Base(configTemplatePath)
+		configPath := path.Join(consts.ConfigMountPoint, configFileName)
+		configPaths = append(configPaths, configPath)
 
-	for _, envVar := range getDefaultEnv() {
-		substituteEnvCommand(envVar.Name)
+		fmt.Fprintf(&command, "echo 'Postprocess config %v';", configFileName)
+		fmt.Fprintf(&postprocessScript, "cp %v %v; ", configTemplatePath, configPath)
+
+		for _, envVar := range getDefaultEnv() {
+			substituteEnvCommand(configPath, envVar.Name)
+		}
+
+		substitutePlaceholderWithCommand(configPath, "POD_FQDN", "hostname -f")
+		substitutePlaceholderWithCommand(configPath, "POD_SHORT_HOSTNAME", "hostname -s")
 	}
-
-	substitutePlaceholderWithCommand("POD_FQDN", "hostname -f")
-	substitutePlaceholderWithCommand("POD_SHORT_HOSTNAME", "hostname -s")
 
 	fmt.Fprintf(&command, "echo '%v' > %v; ", postprocessScript.String(), postprocessScriptPath)
 	fmt.Fprintf(&command, "chmod +x '%v'; ", postprocessScriptPath)
 	fmt.Fprintf(&command, "source %v; ", postprocessScriptPath)
-	fmt.Fprintf(&command, "cat %v; ", configPath)
+	for _, configPath := range configPaths {
+		fmt.Fprintf(&command, "cat %v; ", configPath)
+	}
 
 	return command.String()
 }

--- a/pkg/components/volume.go
+++ b/pkg/components/volume.go
@@ -199,48 +199,43 @@ func getLocationInitCommand(locations []ytv1.LocationSpec) string {
 	return command.String()
 }
 
-func getConfigPostprocessingCommand(configTemplatePaths ...string) string {
+func getConfigPostprocessingCommand(postprocessScriptName, configTemplatePath string) string {
 	var command strings.Builder
 
 	// Store postprocessing as a script on filesystem to ease up manual
 	// config re-initialization without pod recreation. This will be useful
 	// when operator starts restarting processes without container recreation.
 
-	postprocessScriptPath := path.Join(consts.ConfigMountPoint, consts.PostprocessConfigScriptName)
+	configFileName := path.Base(configTemplatePath)
+	configPath := path.Join(consts.ConfigMountPoint, configFileName)
+	postprocessScriptPath := path.Join(consts.ConfigMountPoint, postprocessScriptName)
 
 	var postprocessScript strings.Builder
 
-	substituteEnvCommand := func(configPath, envVar string) {
+	substituteEnvCommand := func(envVar string) {
 		// Replace placeholder {envVar} with the actual value of environment variable envVar.
 		fmt.Fprintf(&postprocessScript, "sed -i -s \"s/{%v}/${%v}/g\" %v; ", envVar, envVar, configPath)
 	}
 
-	substitutePlaceholderWithCommand := func(configPath, placeholder, command string) {
+	substitutePlaceholderWithCommand := func(placeholder, command string) {
 		// Replace placeholder {placeholder} with the output of the given command.
 		fmt.Fprintf(&postprocessScript, "sed -i -s \"s/{%v}/$(%v)/g\" %v; ", placeholder, command, configPath)
 	}
 
-	for _, configTemplatePath := range configTemplatePaths {
-		configFileName := path.Base(configTemplatePath)
-		configPath := path.Join(consts.ConfigMountPoint, configFileName)
+	fmt.Fprintf(&command, "echo 'Postprocess config %v';", configFileName)
+	fmt.Fprintf(&postprocessScript, "cp %v %v; ", configTemplatePath, configPath)
 
-		fmt.Fprintf(&command, "echo 'Postprocess config %v';", configFileName)
-		fmt.Fprintf(&postprocessScript, "cp %v %v; ", configTemplatePath, configPath)
-
-		for _, envVar := range getDefaultEnv() {
-			substituteEnvCommand(configPath, envVar.Name)
-		}
-
-		substitutePlaceholderWithCommand(configPath, "POD_FQDN", "hostname -f")
-		substitutePlaceholderWithCommand(configPath, "POD_SHORT_HOSTNAME", "hostname -s")
+	for _, envVar := range getDefaultEnv() {
+		substituteEnvCommand(envVar.Name)
 	}
+
+	substitutePlaceholderWithCommand("POD_FQDN", "hostname -f")
+	substitutePlaceholderWithCommand("POD_SHORT_HOSTNAME", "hostname -s")
 
 	fmt.Fprintf(&command, "echo '%v' > %v; ", postprocessScript.String(), postprocessScriptPath)
 	fmt.Fprintf(&command, "chmod +x '%v'; ", postprocessScriptPath)
 	fmt.Fprintf(&command, "source %v; ", postprocessScriptPath)
-	for _, configTemplatePath := range configTemplatePaths {
-		fmt.Fprintf(&command, "cat %v; ", path.Join(consts.ConfigMountPoint, path.Base(configTemplatePath)))
-	}
+	fmt.Fprintf(&command, "cat %v; ", configPath)
 
 	return command.String()
 }

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -1574,9 +1574,9 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 					}
 				}
 				Expect(ttContainer).NotTo(BeNil(), "timbertruck container must be present")
-				Expect(ttContainer.Command).To(HaveLen(3))
-				Expect(ttContainer.Command[2]).To(ContainSubstring(
-					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName))
+				Expect(ttContainer.Command).To(Equal([]string{
+					"/usr/bin/timbertruck_os", "-config", consts.ConfigMountPoint + "/" + configFileName,
+				}))
 
 				configMounted := false
 				for _, m := range ttContainer.VolumeMounts {
@@ -1661,9 +1661,9 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 					}
 				}
 				Expect(ttContainer).NotTo(BeNil(), "timbertruck container must be present")
-				Expect(ttContainer.Command).To(HaveLen(3))
-				Expect(ttContainer.Command[2]).To(ContainSubstring(
-					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName))
+				Expect(ttContainer.Command).To(Equal([]string{
+					"/usr/bin/timbertruck_os", "-config", consts.ConfigMountPoint + "/" + configFileName,
+				}))
 
 				configMounted := false
 				for _, m := range ttContainer.VolumeMounts {

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -1574,9 +1574,8 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 					}
 				}
 				Expect(ttContainer).NotTo(BeNil(), "timbertruck container must be present")
-				Expect(ttContainer.Command).To(HaveLen(3))
-				Expect(ttContainer.Command[2]).To(ContainSubstring(
-					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName))
+				Expect(ttContainer.Command).To(ContainElement(ContainSubstring(
+					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName)))
 
 				configMounted := false
 				for _, m := range ttContainer.VolumeMounts {
@@ -1661,9 +1660,8 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 					}
 				}
 				Expect(ttContainer).NotTo(BeNil(), "timbertruck container must be present")
-				Expect(ttContainer.Command).To(HaveLen(3))
-				Expect(ttContainer.Command[2]).To(ContainSubstring(
-					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName))
+				Expect(ttContainer.Command).To(ContainElement(ContainSubstring(
+					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName)))
 
 				configMounted := false
 				for _, m := range ttContainer.VolumeMounts {

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -1574,9 +1574,9 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 					}
 				}
 				Expect(ttContainer).NotTo(BeNil(), "timbertruck container must be present")
-				Expect(ttContainer.Command).To(Equal([]string{
-					"/usr/bin/timbertruck_os", "-config", consts.ConfigMountPoint + "/" + configFileName,
-				}))
+				Expect(ttContainer.Command).To(HaveLen(3))
+				Expect(ttContainer.Command[2]).To(ContainSubstring(
+					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName))
 
 				configMounted := false
 				for _, m := range ttContainer.VolumeMounts {
@@ -1661,9 +1661,9 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 					}
 				}
 				Expect(ttContainer).NotTo(BeNil(), "timbertruck container must be present")
-				Expect(ttContainer.Command).To(Equal([]string{
-					"/usr/bin/timbertruck_os", "-config", consts.ConfigMountPoint + "/" + configFileName,
-				}))
+				Expect(ttContainer.Command).To(HaveLen(3))
+				Expect(ttContainer.Command[2]).To(ContainSubstring(
+					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName))
 
 				configMounted := false
 				for _, m := range ttContainer.VolumeMounts {

--- a/test/e2e/ytsaurus_controller_test.go
+++ b/test/e2e/ytsaurus_controller_test.go
@@ -1574,18 +1574,18 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 					}
 				}
 				Expect(ttContainer).NotTo(BeNil(), "timbertruck container must be present")
-				Expect(ttContainer.Command).To(Equal([]string{
-					"/usr/bin/timbertruck_os", "-config", consts.TimbertruckConfigMountPoint + "/" + configFileName,
-				}))
+				Expect(ttContainer.Command).To(HaveLen(3))
+				Expect(ttContainer.Command[2]).To(ContainSubstring(
+					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName))
 
 				configMounted := false
 				for _, m := range ttContainer.VolumeMounts {
-					if m.MountPath == consts.TimbertruckConfigMountPoint {
+					if m.MountPath == consts.ConfigMountPoint {
 						configMounted = true
 						break
 					}
 				}
-				Expect(configMounted).To(BeTrueBecause("timbertruck container must mount " + consts.TimbertruckConfigMountPoint))
+				Expect(configMounted).To(BeTrueBecause("timbertruck container must mount " + consts.ConfigMountPoint))
 			})
 
 		}) // update timbertruck
@@ -1661,18 +1661,18 @@ var _ = Describe("Basic e2e test for Ytsaurus controller", Label("e2e"), func() 
 					}
 				}
 				Expect(ttContainer).NotTo(BeNil(), "timbertruck container must be present")
-				Expect(ttContainer.Command).To(Equal([]string{
-					"/usr/bin/timbertruck_os", "-config", consts.TimbertruckConfigMountPoint + "/" + configFileName,
-				}))
+				Expect(ttContainer.Command).To(HaveLen(3))
+				Expect(ttContainer.Command[2]).To(ContainSubstring(
+					"exec /usr/bin/timbertruck_os -config " + consts.ConfigMountPoint + "/" + configFileName))
 
 				configMounted := false
 				for _, m := range ttContainer.VolumeMounts {
-					if m.MountPath == consts.TimbertruckConfigMountPoint {
+					if m.MountPath == consts.ConfigMountPoint {
 						configMounted = true
 						break
 					}
 				}
-				Expect(configMounted).To(BeTrueBecause("timbertruck container must mount " + consts.TimbertruckConfigMountPoint))
+				Expect(configMounted).To(BeTrueBecause("timbertruck container must mount " + consts.ConfigMountPoint))
 
 				By("Checking timbertruck was prepared")
 				EventuallyYtsaurus(ctx, ytsaurus, reactionTimeout).Should(HaveStatusConditionTrue(consts.ConditionTimbertruckPrepared))

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
@@ -136,18 +136,9 @@ spec:
         - mountPath: /shared-binaries
           name: shared-binaries
       - command:
-        - bash
-        - -xc
-        - echo 'Postprocess config yt-master-timbertruck.yaml';echo 'cp /etc/timbertruck/yt-master-timbertruck.yaml
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_POD_NAME}/${K8S_POD_NAME}/g"
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_POD_NAMESPACE}/${K8S_POD_NAMESPACE}/g"
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_NODE_NAME}/${K8S_NODE_NAME}/g"
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{POD_FQDN}/$(hostname -f)/g"
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{POD_SHORT_HOSTNAME}/$(hostname
-          -s)/g" /config/yt-master-timbertruck.yaml; ' > /config/postprocess-timbertruck-config.sh;
-          chmod +x '/config/postprocess-timbertruck-config.sh'; source /config/postprocess-timbertruck-config.sh;
-          cat /config/yt-master-timbertruck.yaml;  exec /usr/bin/timbertruck_os -config
-          /config/yt-master-timbertruck.yaml
+        - /usr/bin/timbertruck_os
+        - -config
+        - /config/yt-master-timbertruck.yaml
         env:
         - name: YT_TOKEN
           valueFrom:
@@ -181,9 +172,6 @@ spec:
           name: logs
         - mountPath: /yt/master-logs
           name: master-logs
-        - mountPath: /etc/timbertruck
-          name: timbertruck-config
-          readOnly: true
         - mountPath: /config
           name: config
         - mountPath: /etc/ssl/certs
@@ -289,15 +277,22 @@ spec:
       - command:
         - bash
         - -xc
-        - 'echo ''Postprocess config ytserver-master.yson'';echo ''cp /config_template/ytserver-master.yson
+        - 'echo ''Postprocess config ytserver-master.yson'';echo ''Postprocess config
+          yt-master-timbertruck.yaml'';echo ''cp /config_template/ytserver-master.yson
           /config/ytserver-master.yson; sed -i -s "s/{K8S_POD_NAME}/${K8S_POD_NAME}/g"
           /config/ytserver-master.yson; sed -i -s "s/{K8S_POD_NAMESPACE}/${K8S_POD_NAMESPACE}/g"
           /config/ytserver-master.yson; sed -i -s "s/{K8S_NODE_NAME}/${K8S_NODE_NAME}/g"
           /config/ytserver-master.yson; sed -i -s "s/{POD_FQDN}/$(hostname -f)/g"
           /config/ytserver-master.yson; sed -i -s "s/{POD_SHORT_HOSTNAME}/$(hostname
-          -s)/g" /config/ytserver-master.yson; '' > /config/postprocess-config.sh;
+          -s)/g" /config/ytserver-master.yson; cp /etc/timbertruck/yt-master-timbertruck.yaml
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_POD_NAME}/${K8S_POD_NAME}/g"
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_POD_NAMESPACE}/${K8S_POD_NAMESPACE}/g"
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_NODE_NAME}/${K8S_NODE_NAME}/g"
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{POD_FQDN}/$(hostname -f)/g"
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{POD_SHORT_HOSTNAME}/$(hostname
+          -s)/g" /config/yt-master-timbertruck.yaml; '' > /config/postprocess-config.sh;
           chmod +x ''/config/postprocess-config.sh''; source /config/postprocess-config.sh;
-          cat /config/ytserver-master.yson; '
+          cat /config/ytserver-master.yson; cat /config/yt-master-timbertruck.yaml; '
         env:
         - name: K8S_POD_NAME
           valueFrom:
@@ -338,6 +333,9 @@ spec:
           readOnly: true
         - mountPath: /config
           name: config
+        - mountPath: /etc/timbertruck
+          name: timbertruck-config
+          readOnly: true
         - mountPath: /etc/ssl/certs
           name: ca-root-bundle
           readOnly: true

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
@@ -136,9 +136,10 @@ spec:
         - mountPath: /shared-binaries
           name: shared-binaries
       - command:
-        - /usr/bin/timbertruck_os
-        - -config
-        - /config/yt-master-timbertruck.yaml
+        - bash
+        - -c
+        - source /config/postprocess-timbertruck-config.sh; exec /usr/bin/timbertruck_os
+          -config /config/yt-master-timbertruck.yaml
         env:
         - name: YT_TOKEN
           valueFrom:
@@ -172,6 +173,9 @@ spec:
           name: logs
         - mountPath: /yt/master-logs
           name: master-logs
+        - mountPath: /etc/timbertruck
+          name: timbertruck-config
+          readOnly: true
         - mountPath: /config
           name: config
         - mountPath: /etc/ssl/certs
@@ -277,22 +281,23 @@ spec:
       - command:
         - bash
         - -xc
-        - 'echo ''Postprocess config ytserver-master.yson'';echo ''Postprocess config
-          yt-master-timbertruck.yaml'';echo ''cp /config_template/ytserver-master.yson
+        - 'echo ''Postprocess config ytserver-master.yson'';echo ''cp /config_template/ytserver-master.yson
           /config/ytserver-master.yson; sed -i -s "s/{K8S_POD_NAME}/${K8S_POD_NAME}/g"
           /config/ytserver-master.yson; sed -i -s "s/{K8S_POD_NAMESPACE}/${K8S_POD_NAMESPACE}/g"
           /config/ytserver-master.yson; sed -i -s "s/{K8S_NODE_NAME}/${K8S_NODE_NAME}/g"
           /config/ytserver-master.yson; sed -i -s "s/{POD_FQDN}/$(hostname -f)/g"
           /config/ytserver-master.yson; sed -i -s "s/{POD_SHORT_HOSTNAME}/$(hostname
-          -s)/g" /config/ytserver-master.yson; cp /etc/timbertruck/yt-master-timbertruck.yaml
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_POD_NAME}/${K8S_POD_NAME}/g"
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_POD_NAMESPACE}/${K8S_POD_NAMESPACE}/g"
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_NODE_NAME}/${K8S_NODE_NAME}/g"
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{POD_FQDN}/$(hostname -f)/g"
-          /config/yt-master-timbertruck.yaml; sed -i -s "s/{POD_SHORT_HOSTNAME}/$(hostname
-          -s)/g" /config/yt-master-timbertruck.yaml; '' > /config/postprocess-config.sh;
+          -s)/g" /config/ytserver-master.yson; '' > /config/postprocess-config.sh;
           chmod +x ''/config/postprocess-config.sh''; source /config/postprocess-config.sh;
-          cat /config/ytserver-master.yson; cat /config/yt-master-timbertruck.yaml; '
+          cat /config/ytserver-master.yson; echo ''Postprocess config yt-master-timbertruck.yaml'';echo
+          ''cp /etc/timbertruck/yt-master-timbertruck.yaml /config/yt-master-timbertruck.yaml;
+          sed -i -s "s/{K8S_POD_NAME}/${K8S_POD_NAME}/g" /config/yt-master-timbertruck.yaml;
+          sed -i -s "s/{K8S_POD_NAMESPACE}/${K8S_POD_NAMESPACE}/g" /config/yt-master-timbertruck.yaml;
+          sed -i -s "s/{K8S_NODE_NAME}/${K8S_NODE_NAME}/g" /config/yt-master-timbertruck.yaml;
+          sed -i -s "s/{POD_FQDN}/$(hostname -f)/g" /config/yt-master-timbertruck.yaml;
+          sed -i -s "s/{POD_SHORT_HOSTNAME}/$(hostname -s)/g" /config/yt-master-timbertruck.yaml;
+          '' > /config/postprocess-timbertruck-config.sh; chmod +x ''/config/postprocess-timbertruck-config.sh'';
+          source /config/postprocess-timbertruck-config.sh; cat /config/yt-master-timbertruck.yaml; '
         env:
         - name: K8S_POD_NAME
           valueFrom:

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet ms.yaml
@@ -136,9 +136,18 @@ spec:
         - mountPath: /shared-binaries
           name: shared-binaries
       - command:
-        - /usr/bin/timbertruck_os
-        - -config
-        - /etc/timbertruck/yt-master-timbertruck.yaml
+        - bash
+        - -xc
+        - echo 'Postprocess config yt-master-timbertruck.yaml';echo 'cp /etc/timbertruck/yt-master-timbertruck.yaml
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_POD_NAME}/${K8S_POD_NAME}/g"
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_POD_NAMESPACE}/${K8S_POD_NAMESPACE}/g"
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{K8S_NODE_NAME}/${K8S_NODE_NAME}/g"
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{POD_FQDN}/$(hostname -f)/g"
+          /config/yt-master-timbertruck.yaml; sed -i -s "s/{POD_SHORT_HOSTNAME}/$(hostname
+          -s)/g" /config/yt-master-timbertruck.yaml; ' > /config/postprocess-timbertruck-config.sh;
+          chmod +x '/config/postprocess-timbertruck-config.sh'; source /config/postprocess-timbertruck-config.sh;
+          cat /config/yt-master-timbertruck.yaml;  exec /usr/bin/timbertruck_os -config
+          /config/yt-master-timbertruck.yaml
         env:
         - name: YT_TOKEN
           valueFrom:
@@ -175,6 +184,8 @@ spec:
         - mountPath: /etc/timbertruck
           name: timbertruck-config
           readOnly: true
+        - mountPath: /config
+          name: config
         - mountPath: /etc/ssl/certs
           name: ca-root-bundle
           readOnly: true


### PR DESCRIPTION
Server component configs go through the `postprocess-config` init container, which copies them from a read-only template mount into a writable volume and substitutes `{POD_FQDN}`, `{POD_SHORT_HOSTNAME}` and the default env vars. The timbertruck sidecar config was a separate branch: it was mounted straight from its ConfigMap, so placeholders reached the sidecar as literal text and its sensors ended up without a per-pod label.

The sidecar config now goes through the same postprocessing. `getConfigPostprocessingCommand` takes the script name and the config template path, so it can be reused for a second config, and the init container runs it for both. The sidecar keeps its ConfigMap mounted and sources that script again on every start, so a configmap re-sync still reaches a running pod, as it did when the sidecar read the ConfigMap directly. Placeholders become available in the sidecar config:

```yaml
admin_panel:
    monitoring_tags:
        host: "{POD_SHORT_HOSTNAME}"
```

Two notes: the generated config carries no placeholders today, so this only takes effect through `spec.configOverrides`; and `prepareTimbertruckTables` creates the Cypress nodes from the raw config, so placeholders must not be used in queue or producer paths.
