### PR TITLE
Use master instance options for yt-client-init-job-user

### DIFF
--- a/pkg/components/init_job.go
+++ b/pkg/components/init_job.go
@@ -313,7 +313,11 @@ func (j *InitJob) Build() *batchv1.Job {
 		logMounts, err := resolveLocationMounts(j.instanceSpec, ytv1.LocationTypeInitJobLogs)
 		if err == nil && len(logMounts) != 0 {
 			job.Spec.Template.Spec.Containers[0].VolumeMounts = append(job.Spec.Template.Spec.Containers[0].VolumeMounts, logMounts...)
-			pvcSuffix := fmt.Sprintf("-%s-0", j.labeller.GetComponentShortName())
+			ownerName := j.labeller.GetComponentShortName()
+			if j.labeller.ComponentType == consts.YtsaurusClientType {
+				ownerName = j.labeller.ForComponent(consts.MasterType, "").GetComponentShortName()
+			}
+			pvcSuffix := fmt.Sprintf("-%s-0", ownerName)
 			job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, resolveVolumeMounts(j.instanceSpec, logMounts, pvcSuffix)...)
 		}
 	}

--- a/pkg/components/ytsaurus_client.go
+++ b/pkg/components/ytsaurus_client.go
@@ -88,7 +88,7 @@ func NewYtsaurusClient(
 			l,
 			ytsaurus,
 			"user",
-			&ytv1.InstanceSpec{},
+			&resource.Spec.PrimaryMasters.InstanceSpec,
 			YsonConfigGenerator(consts.ClientConfigFileName, cfgen.GetNativeClientConfig),
 		),
 		secret: resources.NewStringSecret(

--- a/test/r8r/canondata/Components reconciler With all components Test/Job yt-client-init-job-user.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Job yt-client-init-job-user.yaml
@@ -42,8 +42,8 @@ spec:
       containers:
       - command:
         - /bin/bash
-        - -eux
-        - /config/init-job-script.sh
+        - -euxc
+        - exec &> >(tee -a /yt/master-logs/yt-client-init-job-user.log); . /config/init-job-script.sh
         env:
         - name: K8S_POD_NAME
           valueFrom:
@@ -80,19 +80,20 @@ spec:
         - mountPath: /tls/bus_client_secret
           name: bus-client-secret
           readOnly: true
+        - mountPath: /yt/master-logs
+          name: master-logs
       dnsConfig:
         options:
-        - name: global-dns-option
-      dnsPolicy: ClusterFirst
-      hostNetwork: true
+        - name: instance-dns-option
+      dnsPolicy: None
       imagePullSecrets:
       - name: global-image-pull-secrets
       nodeSelector:
-        global-node-selector: "true"
+        instance-node-selector: "true"
       restartPolicy: OnFailure
-      setHostnameAsFQDN: false
+      setHostnameAsFQDN: true
       tolerations:
-      - key: global-toleration
+      - key: instance-toleration
       volumes:
       - configMap:
           defaultMode: 320
@@ -112,6 +113,9 @@ spec:
       - name: bus-client-secret
         secret:
           secretName: native-client-cert
+      - name: master-logs
+        persistentVolumeClaim:
+          claimName: master-logs-ms-0
 status:
   conditions:
   - lastProbeTime: null

--- a/test/r8r/components_test.go
+++ b/test/r8r/components_test.go
@@ -754,7 +754,7 @@ var _ = Describe("Components reconciler", Label("reconciler"), func() {
 				podSpec := &job.Spec.Template.Spec
 				Expect(podSpec.ImagePullSecrets).To(Equal(ytsaurus.Spec.ImagePullSecrets))
 				options := &ytsaurus.Spec.PodSpec
-				if strings.HasPrefix(job.Name, "yt-master-") {
+				if strings.HasPrefix(job.Name, "yt-master-") || strings.HasPrefix(job.Name, "yt-client-") {
 					options = &ytsaurus.Spec.PrimaryMasters.PodSpec
 				}
 				Expect(podSpec.Tolerations).To(Equal(options.Tolerations))


### PR DESCRIPTION
YT client init job is special because it has no owning server component.
Let's use master instance, because all it needs is native client.

This also gives it recently added init job logging.

All changes are neatly caught by r8r test.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
