### PR TITLE
Enable warning logs for native clients

### DIFF
--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/NativeClientConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/NativeClientConfig/test.canondata
@@ -6,8 +6,20 @@
     };
     logging={
         writers={
+            stderr={
+                type=stderr;
+                format="plain_text";
+                "enable_system_messages"=%true;
+            };
         };
         rules=[
+            {
+                "min_level"=warning;
+                writers=[
+                    stderr;
+                ];
+                family="plain_text";
+            };
         ];
     };
     driver={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/NativeClientConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/NativeClientConfig/test.canondata
@@ -6,8 +6,20 @@
     };
     logging={
         writers={
+            stderr={
+                type=stderr;
+                format="plain_text";
+                "enable_system_messages"=%true;
+            };
         };
         rules=[
+            {
+                "min_level"=warning;
+                writers=[
+                    stderr;
+                ];
+                family="plain_text";
+            };
         ];
     };
     driver={

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/NativeClientConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/NativeClientConfig/test.canondata
@@ -6,8 +6,20 @@
     };
     logging={
         writers={
+            stderr={
+                type=stderr;
+                format="plain_text";
+                "enable_system_messages"=%true;
+            };
         };
         rules=[
+            {
+                "min_level"=warning;
+                writers=[
+                    stderr;
+                ];
+                family="plain_text";
+            };
         ];
     };
     driver={

--- a/pkg/ytconfig/generator.go
+++ b/pkg/ytconfig/generator.go
@@ -761,6 +761,7 @@ func getNativeClientConfigCarcass() (NativeClientConfig, error) {
 	var c NativeClientConfig
 
 	loggingBuilder := newLoggingBuilder(nil, "client")
+	loggingBuilder.addLogger(defaultClientStderrLoggerSpec())
 	c.Logging = loggingBuilder.logging
 
 	return c, nil

--- a/pkg/ytconfig/logging.go
+++ b/pkg/ytconfig/logging.go
@@ -24,6 +24,19 @@ func defaultStderrLoggerSpec() ytv1.TextLoggerSpec {
 	}
 }
 
+func defaultClientStderrLoggerSpec() ytv1.TextLoggerSpec {
+	return ytv1.TextLoggerSpec{
+		BaseLoggerSpec: ytv1.BaseLoggerSpec{
+			Name:               "stderr",
+			MinLogLevel:        ytv1.LogLevelWarning,
+			Compression:        ytv1.LogCompressionNone,
+			UseTimestampSuffix: false,
+			Format:             ytv1.LogFormatPlainText,
+		},
+		WriterType: ytv1.LogWriterTypeStderr,
+	}
+}
+
 func defaultDebugLoggerSpec() ytv1.TextLoggerSpec {
 	return ytv1.TextLoggerSpec{
 		BaseLoggerSpec: ytv1.BaseLoggerSpec{

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-2-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-2-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-3-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-3-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-4-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-4-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-2-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-2-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-chyt-test-ytsaurus-init-job-release-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-chyt-test-ytsaurus-init-job-release-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-chyt-test-ytsaurus-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-chyt-test-ytsaurus-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-spyt-test-ytsaurus-init-job-spyt-environment-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-spyt-test-ytsaurus-init-job-spyt-environment-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-spyt-test-ytsaurus-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-spyt-test-ytsaurus-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-2-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-2-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-strawberry-controller-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-strawberry-controller-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-ui-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-ui-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-yql-agent-init-job-yql-agent-environment-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-yql-agent-init-job-yql-agent-environment-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-client-init-job-user-config.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-client-init-job-user-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-master-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-master-init-job-default-config.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-master-init-job-default-config.yaml
@@ -8,8 +8,20 @@ data:
         };
         logging={
             writers={
+                stderr={
+                    type=stderr;
+                    format="plain_text";
+                    "enable_system_messages"=%true;
+                };
             };
             rules=[
+                {
+                    "min_level"=warning;
+                    writers=[
+                        stderr;
+                    ];
+                    family="plain_text";
+                };
             ];
         };
         driver={


### PR DESCRIPTION
This change will able to debug problems in native clients, for example, the custom-yt-init-job can failing quietly now (incident with [bug](https://github.com/ytsaurus/ytsaurus/commit/9b98ab7ed920efbab9048368eb53847ac48c00bd) in ares), and also other calls yt tool, these make connections via native protocols. 