### PR TITLE
Add current workflow file into setup-go cache-dependency-path

### DIFF
--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-          cache-dependency-path: '**/go.mod'
+          cache-dependency-path: |
+            **/go.mod
+            ${{ job.workflow_file_path }}
 
       - name: Run code linters
         shell: bash

--- a/.github/workflows/subflow_release.yaml
+++ b/.github/workflows/subflow_release.yaml
@@ -25,7 +25,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-          cache-dependency-path: '**/go.mod'
+          cache-dependency-path: |
+            **/go.mod
+            ${{ job.workflow_file_path }}
 
       # https://github.com/Azure/setup-helm
       # https://github.com/helm/helm/releases

--- a/.github/workflows/subflow_run_compat_tests.yaml
+++ b/.github/workflows/subflow_run_compat_tests.yaml
@@ -29,7 +29,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-          cache-dependency-path: '**/go.mod'
+          cache-dependency-path: |
+            **/go.mod
+            ${{ job.workflow_file_path }}
 
       # https://github.com/Azure/setup-helm
       # https://github.com/helm/helm/releases

--- a/.github/workflows/subflow_run_e2e_tests.yaml
+++ b/.github/workflows/subflow_run_e2e_tests.yaml
@@ -90,7 +90,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-          cache-dependency-path: '**/go.mod'
+          cache-dependency-path: |
+            **/go.mod
+            ${{ job.workflow_file_path }}
 
       # https://github.com/Azure/setup-helm
       # https://github.com/helm/helm/releases

--- a/.github/workflows/subflow_run_unit_tests.yaml
+++ b/.github/workflows/subflow_run_unit_tests.yaml
@@ -46,7 +46,9 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-          cache-dependency-path: '**/go.mod'
+          cache-dependency-path: |
+            **/go.mod
+            ${{ job.workflow_file_path }}
 
       - name: Run unit tests
         shell: bash


### PR DESCRIPTION
Different workflows needs different subset of modules.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
