### PR TITLE
Default location QUOTA should came from volume storage LIMIT

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -206,10 +206,14 @@ type LocationSpec struct {
 	//+kubebuilder:default:=default
 	Medium string `json:"medium,omitempty"`
 
-	// Disk space quota, default is size of related volume.
+	// Disk space quota, default is storage limit of related volume, otherwise - unlimited.
 	//+optional
 	Quota *resource.Quantity `json:"quota,omitempty"`
-	// Limit above which the volume is considered to be non-full.
+	// Free disk space above which the location is considered to be non-full.
+	// Default: min((quota or storage request)/10, 25GiB).
+	// Below lowWatermark the location starts collecting trash.
+	// Below lowWatermark/2 the location is considered to be full.
+	// Below lowWatermark/4 the location stops accepting new writes.
 	//+optional
 	LowWatermark *resource.Quantity `json:"lowWatermark,omitempty"`
 	// Max TTL of trash in milliseconds.

--- a/pkg/consts/defaults.go
+++ b/pkg/consts/defaults.go
@@ -29,6 +29,8 @@ const DefaultHTTPProxyRole = "default"
 const DefaultName = "default"
 const DefaultMedium = "default"
 
+const MaxChunkStoreLocationReserve = 25 << 30 // 25GiB
+
 const MaxSlotLocationReserve = 10 << 30 // 10GiB
 
 const DefaultStrawberryControllerFamily = "chyt"

--- a/pkg/testutil/spec_builders.go
+++ b/pkg/testutil/spec_builders.go
@@ -178,6 +178,7 @@ func init() {
 var (
 	masterVolumeSize   = resource.MustParse("5Gi")
 	dataNodeVolumeSize = resource.MustParse("10Gi")
+	dataNodeVolumeLim  = resource.MustParse("20Gi")
 	execNodeVolumeSize = resource.MustParse("5Gi")
 	logsVolumeSize     = resource.MustParse("1Gi")
 	logsSegmentSize    = resource.MustParse("100Mi")
@@ -249,6 +250,12 @@ func (b *YtsaurusBuilder) CreateVolumeClaim(name string, size resource.Quantity)
 			},
 		},
 	}
+}
+
+func (b *YtsaurusBuilder) CreateVolumeClaimWithLimit(name string, request, limit resource.Quantity) ytv1.EmbeddedPersistentVolumeClaim {
+	vol := b.CreateVolumeClaim(name, request)
+	vol.Spec.Resources.Limits = corev1.ResourceList{corev1.ResourceStorage: limit}
+	return vol
 }
 
 func (b *YtsaurusBuilder) addLogsVolume(spec *ytv1.InstanceSpec, name string) {
@@ -831,7 +838,7 @@ func (b *YtsaurusBuilder) CreateDataNodeInstanceSpec(instanceCount int32) ytv1.I
 			},
 		},
 		VolumeClaimTemplates: []ytv1.EmbeddedPersistentVolumeClaim{
-			b.CreateVolumeClaim("node-data", dataNodeVolumeSize),
+			b.CreateVolumeClaimWithLimit("node-data", dataNodeVolumeSize, dataNodeVolumeLim),
 		},
 		VolumeMounts: []corev1.VolumeMount{
 			{

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-trash-ttl/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/with-trash-ttl/test.canondata
@@ -113,8 +113,8 @@
         "store_locations"=[
             {
                 path="/yt/hdd1/chunk-store";
+                "min_disk_space"=1073741824;
                 "medium_name"=nvme;
-                quota=10737418240;
                 "high_watermark"=536870912;
                 "low_watermark"=1073741824;
                 "disable_writes_watermark"=268435456;

--- a/pkg/ytconfig/canondata/TestGetDataNodeConfig/without-trash-ttl/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeConfig/without-trash-ttl/test.canondata
@@ -113,8 +113,8 @@
         "store_locations"=[
             {
                 path="/yt/hdd1/chunk-store";
+                "min_disk_space"=1073741824;
                 "medium_name"=nvme;
-                quota=10737418240;
                 "high_watermark"=536870912;
                 "low_watermark"=1073741824;
                 "disable_writes_watermark"=268435456;

--- a/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetDataNodeWithoutYtsaurusConfig/test.canondata
@@ -115,8 +115,8 @@
         "store_locations"=[
             {
                 path="/yt/hdd1/chunk-store";
+                "min_disk_space"=1073741824;
                 "medium_name"=nvme;
-                quota=10737418240;
                 "high_watermark"=536870912;
                 "low_watermark"=1073741824;
                 "disable_writes_watermark"=268435456;

--- a/pkg/ytconfig/canondata/TestGetYtsaurusComponents/DataNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusComponents/DataNode/test.canondata
@@ -113,8 +113,8 @@
         "store_locations"=[
             {
                 path="/yt/hdd1/chunk-store";
+                "min_disk_space"=1073741824;
                 "medium_name"=nvme;
-                quota=10737418240;
                 "high_watermark"=536870912;
                 "low_watermark"=1073741824;
                 "disable_writes_watermark"=268435456;

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/DataNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithMutualTLSInterconnect/DataNode/test.canondata
@@ -141,8 +141,8 @@
         "store_locations"=[
             {
                 path="/yt/hdd1/chunk-store";
+                "min_disk_space"=1073741824;
                 "medium_name"=nvme;
-                quota=10737418240;
                 "high_watermark"=536870912;
                 "low_watermark"=1073741824;
                 "disable_writes_watermark"=268435456;

--- a/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/DataNode/test.canondata
+++ b/pkg/ytconfig/canondata/TestGetYtsaurusWithTlsInterconnect/DataNode/test.canondata
@@ -131,8 +131,8 @@
         "store_locations"=[
             {
                 path="/yt/hdd1/chunk-store";
+                "min_disk_space"=1073741824;
                 "medium_name"=nvme;
-                quota=10737418240;
                 "high_watermark"=536870912;
                 "low_watermark"=1073741824;
                 "disable_writes_watermark"=268435456;

--- a/pkg/ytconfig/node.go
+++ b/pkg/ytconfig/node.go
@@ -60,7 +60,7 @@ type StoreLocation struct {
 	// Stop writes when available space becomes less than disable-writes watermark.
 	DisableWritesWatermark int64 `yson:"disable_writes_watermark,omitempty"`
 	// Start deleting trash when available space less than trash-cleanup watermark.
-	TrashCleanupWatermark int64 `yson:"trash_cleanup_watermark"`
+	TrashCleanupWatermark int64 `yson:"trash_cleanup_watermark,omitempty"`
 	// Maximum time before permanent deletion.
 	MaxTrashTtl *int64 `yson:"max_trash_ttl,omitempty"`
 }
@@ -364,28 +364,41 @@ func findVolume(volumeName string, spec ytv1.InstanceSpec) *ytv1.Volume {
 	return nil
 }
 
-func findQuotaForLocation(location ytv1.LocationSpec, spec ytv1.InstanceSpec) *int64 {
+func findQuotaForLocation(location ytv1.LocationSpec, spec ytv1.InstanceSpec) (request *int64, limit *int64) {
 	if quota := location.Quota; quota != nil {
-		return ptr.To(quota.Value())
+		val := ptr.To(quota.Value())
+		return val, val // NOTE: location quota overrides both storage request and limit.
 	}
 
 	mount := findVolumeMountForPath(location.Path, spec)
 	if mount == nil {
-		return nil
+		return nil, nil
 	}
 
+	var resources *corev1.VolumeResourceRequirements
 	if claim := findVolumeClaimTemplate(mount.Name, spec); claim != nil {
-		storage := claim.Spec.Resources.Requests.Storage()
-		if storage != nil && !storage.IsZero() {
-			return ptr.To(storage.Value())
-		}
+		resources = &claim.Spec.Resources
 	} else if volume := findVolume(mount.Name, spec); volume != nil {
 		if volume.EmptyDir != nil && volume.EmptyDir.SizeLimit != nil {
-			return ptr.To(volume.EmptyDir.SizeLimit.Value())
+			val := ptr.To(volume.EmptyDir.SizeLimit.Value())
+			return val, val
+		}
+		if volume.Ephemeral != nil && volume.Ephemeral.VolumeClaimTemplate != nil {
+			resources = &volume.Ephemeral.VolumeClaimTemplate.Spec.Resources
 		}
 	}
 
-	return nil
+	if resources != nil {
+		if storage := resources.Requests.Storage(); storage != nil && !storage.IsZero() {
+			request = ptr.To(storage.Value())
+		}
+		if storage := resources.Limits.Storage(); storage != nil && !storage.IsZero() {
+			limit = ptr.To(storage.Value())
+		}
+		return request, limit
+	}
+
+	return nil, nil
 }
 
 func fillClusterNodeServerCarcass(n *NodeServer, flavor NodeFlavor, spec ytv1.ClusterNodesSpec, is *ytv1.InstanceSpec) {
@@ -444,23 +457,26 @@ func getDataNodeServerCarcass(spec *ytv1.DataNodesSpec) (DataNodeServer, error) 
 			},
 		}
 
-		if quota := findQuotaForLocation(location, spec.InstanceSpec); quota != nil {
-			storeLocation.Quota = *quota
-
-			if location.LowWatermark != nil {
-				storeLocation.LowWatermark = location.LowWatermark.Value()
-				storeLocation.MinDiskSpace = storeLocation.LowWatermark
-			} else {
-				gb := float64(1024 * 1024 * 1024)
-				storeLocation.LowWatermark = int64(math.Min(0.1*float64(storeLocation.Quota), float64(25)*gb))
-			}
-
-			// These are just simple heuristics.
+		request, limit := findQuotaForLocation(location, spec.InstanceSpec)
+		if limit != nil {
+			// NOTE: Default quota comes from storage limit.
+			storeLocation.Quota = *limit
+		}
+		if location.LowWatermark != nil {
+			storeLocation.LowWatermark = location.LowWatermark.Value()
+		} else if request != nil {
+			// NOTE: Default low watermark is come from storage request.
+			storeLocation.LowWatermark = int64(math.Min(0.1*float64(*request), float64(consts.MaxChunkStoreLocationReserve)))
+		}
+		if storeLocation.LowWatermark != 0 {
+			storeLocation.MinDiskSpace = storeLocation.LowWatermark
+			// NOTE: These are just simple heuristics, otherwise use some ytserver defaults.
 			storeLocation.HighWatermark = storeLocation.LowWatermark / 2
 			storeLocation.DisableWritesWatermark = storeLocation.HighWatermark / 2
 			storeLocation.TrashCleanupWatermark = storeLocation.LowWatermark
-			storeLocation.MaxTrashTtl = location.MaxTrashMilliseconds
 		}
+		storeLocation.MaxTrashTtl = location.MaxTrashMilliseconds
+
 		c.DataNode.StoreLocations = append(c.DataNode.StoreLocations, storeLocation)
 	}
 
@@ -572,8 +588,9 @@ func fillJobEnvironmentCRI(
 	}
 
 	if location := ytv1.FindFirstLocation(spec.Locations, ytv1.LocationTypeImageCache); location != nil {
+		quota, _ := findQuotaForLocation(*location, spec.InstanceSpec)
 		jobEnv.CriImageCache = &CriImageCache{
-			Capacity:            findQuotaForLocation(*location, spec.InstanceSpec),
+			Capacity:            quota,
 			ImageSizeEstimation: envSpec.CRI.ImageSizeEstimation,
 			AlwaysPullLatest:    envSpec.CRI.AlwaysPullLatestImage,
 		}
@@ -662,7 +679,7 @@ func getExecNodeServerCarcass(spec *ytv1.ExecNodesSpec, commonSpec *ytv1.CommonS
 			cacheLocation.MinDiskSpace = location.LowWatermark.Value()
 		}
 
-		if quota := findQuotaForLocation(location, spec.InstanceSpec); quota != nil {
+		if quota, _ := findQuotaForLocation(location, spec.InstanceSpec); quota != nil {
 			cacheLocation.Quota = *quota
 		}
 
@@ -685,7 +702,7 @@ func getExecNodeServerCarcass(spec *ytv1.ExecNodesSpec, commonSpec *ytv1.CommonS
 			slotLocation.MinDiskSpace = location.LowWatermark.Value()
 		}
 
-		if quota := findQuotaForLocation(location, spec.InstanceSpec); quota != nil {
+		if quota, _ := findQuotaForLocation(location, spec.InstanceSpec); quota != nil {
 			slotLocation.DiskQuota = quota
 
 			// These are just simple heuristics.

--- a/test/r8r/canondata/Components reconciler Remote Data nodes Test/ConfigMap yt-data-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler Remote Data nodes Test/ConfigMap yt-data-node-config.yaml
@@ -87,7 +87,8 @@ data:
             "store_locations"=[
                 {
                     path="/yt/node-data/chunk-store";
-                    quota=10737418240;
+                    "min_disk_space"=1073741824;
+                    quota=21474836480;
                     "high_watermark"=536870912;
                     "low_watermark"=1073741824;
                     "disable_writes_watermark"=268435456;

--- a/test/r8r/canondata/Components reconciler Remote Data nodes Test/RemoteDataNodes.yaml
+++ b/test/r8r/canondata/Components reconciler Remote Data nodes Test/RemoteDataNodes.yaml
@@ -35,6 +35,8 @@ spec:
       accessModes:
       - ReadWriteOnce
       resources:
+        limits:
+          storage: 20Gi
         requests:
           storage: 10Gi
   volumeMounts:

--- a/test/r8r/canondata/Components reconciler Remote Data nodes Test/StatefulSet dnd-rmt.yaml
+++ b/test/r8r/canondata/Components reconciler Remote Data nodes Test/StatefulSet dnd-rmt.yaml
@@ -178,6 +178,8 @@ spec:
       accessModes:
       - ReadWriteOnce
       resources:
+        limits:
+          storage: 20Gi
         requests:
           storage: 10Gi
     status: {}

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-data-node-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-data-node-config.yaml
@@ -154,7 +154,8 @@ data:
             "store_locations"=[
                 {
                     path="/yt/node-data/chunk-store";
-                    quota=10737418240;
+                    "min_disk_space"=1073741824;
+                    quota=21474836480;
                     "io_config"={
                         "enable_sync"=%false;
                     };

--- a/test/r8r/canondata/Components reconciler With all components Test/StatefulSet dnd.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/StatefulSet dnd.yaml
@@ -255,6 +255,8 @@ spec:
       accessModes:
       - ReadWriteOnce
       resources:
+        limits:
+          storage: 20Gi
         requests:
           storage: 10Gi
     status: {}

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -113,6 +113,8 @@ spec:
         accessModes:
         - ReadWriteOnce
         resources:
+          limits:
+            storage: 20Gi
           requests:
             storage: 10Gi
     - metadata:


### PR DESCRIPTION
If both volume storage limit and location quota are not fined then
location should use all available space.

But default low watermark should come from volume storage request.

This is required for full utilization when exact disk sizes are unknown.

Issue: #820
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
