### PR TITLE
Set memory limit in HTTP and RPC proxy configs

### DIFF
--- a/pkg/ytconfig/proxy.go
+++ b/pkg/ytconfig/proxy.go
@@ -71,21 +71,27 @@ type HTTPSServer struct {
 	Credentials HTTPSServerCredentials `yson:"credentials"`
 }
 
+type ProxyMemoryLimits struct {
+	Total int64 `yson:"total"`
+}
+
 type HTTPProxyServer struct {
 	CommonServer
-	Port            int          `yson:"port"`
-	Auth            Auth         `yson:"auth"`
-	Coordinator     Coordinator  `yson:"coordinator"`
-	Driver          Driver       `yson:"driver"`
-	Role            string       `yson:"role"`
-	HTTPSServer     *HTTPSServer `yson:"https_server,omitempty"`
-	ChytHttpServer  *HTTPServer  `yson:"chyt_http_server,omitempty"`
-	ChytHttpsServer *HTTPSServer `yson:"chyt_https_server,omitempty"`
+	Port            int                `yson:"port"`
+	Auth            Auth               `yson:"auth"`
+	Coordinator     Coordinator        `yson:"coordinator"`
+	Driver          Driver             `yson:"driver"`
+	Role            string             `yson:"role"`
+	MemoryLimits    *ProxyMemoryLimits `yson:"memory_limits,omitempty"`
+	HTTPSServer     *HTTPSServer       `yson:"https_server,omitempty"`
+	ChytHttpServer  *HTTPServer        `yson:"chyt_http_server,omitempty"`
+	ChytHttpsServer *HTTPSServer       `yson:"chyt_https_server,omitempty"`
 }
 
 type RPCProxyServer struct {
 	CommonServer
 	Role                      string                    `yson:"role"`
+	MemoryLimits              *ProxyMemoryLimits        `yson:"memory_limits,omitempty"`
 	CypressUserManager        CypressUserManager        `yson:"cypress_user_manager"`
 	CypressTokenAuthenticator CypressTokenAuthenticator `yson:"cypress_token_authenticator"`
 	OauthService              *OauthService             `yson:"oauth_service,omitempty"`
@@ -135,6 +141,10 @@ func getHTTPProxyServerCarcass(spec *ytv1.HTTPProxiesSpec) (HTTPProxyServer, err
 
 	c.Role = spec.Role
 
+	if memory := getResourceQuantity(&spec.Resources, corev1.ResourceMemory); !memory.IsZero() {
+		c.MemoryLimits = &ProxyMemoryLimits{Total: memory.Value()}
+	}
+
 	c.Logging = getHTTPProxyLogging(spec)
 
 	// FIXME handle DisableHTTP
@@ -175,6 +185,11 @@ func getRPCProxyServerCarcass(spec *ytv1.RPCProxiesSpec) (RPCProxyServer, error)
 	c.MonitoringPort = ptr.Deref(spec.MonitoringPort, consts.RPCProxyMonitoringPort)
 
 	c.Role = spec.Role
+
+	if memory := getResourceQuantity(&spec.Resources, corev1.ResourceMemory); !memory.IsZero() {
+		c.MemoryLimits = &ProxyMemoryLimits{Total: memory.Value()}
+	}
+
 	c.Logging = getRPCProxyLogging(spec)
 
 	return c, nil

--- a/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler Image heater only for masters Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cell roles Test/ConfigMap yt-http-proxy-config.yaml
@@ -131,6 +131,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler Master cells maintenance Test/ConfigMap yt-http-proxy-config.yaml
@@ -107,6 +107,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler Minimal Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CHYT Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and METAX container runtime Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime - CRI-O Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI and NVIDIA container runtime Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment - CRI-O Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With CRI job environment Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With SPYT Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-http-proxy-config.yaml
@@ -160,6 +160,9 @@ data:
             "default_rpc_proxy_address_type"="public_rpc";
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
         "https_server"={
             port=443;
             credentials={

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-rpc-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-rpc-proxy-config.yaml
@@ -142,6 +142,9 @@ data:
             "physical_host"="{K8S_NODE_NAME}";
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
         "cypress_user_manager"={
         };
         "cypress_token_authenticator"={

--- a/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-http-proxy-config.yaml
+++ b/test/r8r/canondata/Components reconciler With job proxy logs Test/ConfigMap yt-http-proxy-config.yaml
@@ -93,6 +93,9 @@ data:
         driver={
         };
         role="";
+        "memory_limits"={
+            total=2147483648;
+        };
     }
 metadata:
   annotations:


### PR DESCRIPTION
Proxies needs to know at least total size of available memory.

Issue: #788
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
