### PR TITLE
Tag API module during release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,3 +13,23 @@ jobs:
     secrets: inherit
     with:
       release_version: ${GITHUB_REF#refs/tags/v}
+
+  # https://go.dev/doc/modules/managing-source?#multiple-module-source
+  tag-api-module:
+    name: Tag API module
+    needs: release
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Create API module release tag
+        env:
+          API_TAG: api/${{ github.ref_name }}
+        run: |
+          git tag "${API_TAG}" "${GITHUB_SHA}"
+          git push origin "${API_TAG}"


### PR DESCRIPTION
Sub-module "api" needs own release tags.

Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
