### PR TITLE
Requeue reconcile after update step progress and fix race at UpdateIsPossible

### DIFF
--- a/controllers/update_flow_steps.go
+++ b/controllers/update_flow_steps.go
@@ -162,7 +162,10 @@ func (f *flowTree) execute(ctx context.Context, ytsaurus *apiProxy.Ytsaurus, com
 	)
 
 	err = ytsaurus.SaveUpdateState(ctx, nextStep.updateState)
-	return false, err
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func (f *flowTree) chain(steps ...*flowStep) *flowTree {

--- a/controllers/update_flow_steps.go
+++ b/controllers/update_flow_steps.go
@@ -201,7 +201,8 @@ var flowConditions = map[ytv1.UpdateState]flowCondition{
 		return stepResultMarkUnsatisfied
 	},
 	ytv1.UpdateStatePossibilityCheck: func(ctx context.Context, ytsaurus *apiProxy.Ytsaurus, componentManager *ComponentManager) stepResultMark {
-		if ytsaurus.IsStatusConditionTrue(consts.ConditionUpdateIsPossible) {
+		// NOTE: Update step must see own update of cluster health condition for current generation.
+		if ytsaurus.IsStatusConditionTrueAndObservedGeneration(consts.ConditionUpdateIsPossible) {
 			return stepResultMarkHappy
 		} else if ytsaurus.IsStatusConditionFalse(consts.ConditionUpdateIsPossible) {
 			return stepResultMarkUnhappy

--- a/pkg/components/ytsaurus_client.go
+++ b/pkg/components/ytsaurus_client.go
@@ -407,7 +407,7 @@ func (yc *YtsaurusClient) Sync(ctx context.Context, dry bool) (ComponentStatus, 
 		return status, nil
 	}
 
-	if !yc.ytsaurus.IsStatusConditionTrue(consts.ConditionUpdateIsPossible) {
+	if !yc.ytsaurus.IsStatusConditionTrueAndObservedGeneration(consts.ConditionUpdateIsPossible) {
 		if dry {
 			return ComponentStatusPending("Cluster health checks"), nil
 		}

--- a/test/r8r/components_test.go
+++ b/test/r8r/components_test.go
@@ -415,8 +415,13 @@ var _ = Describe("Components reconciler", Label("reconciler"), func() {
 				log.Info("Reconcile", "kind", req.Kind, "name", req.Name)
 				result, err := reconcilers[req.Kind].Reconcile(ctx, reconcilerRequest)
 				//nolint:staticcheck // Deprecated.
-				if result.Requeue || result.RequeueAfter > 0 {
-					log.Info("Requeue", "kind", req.Kind, "name", req.Name, "delay", result.RequeueAfter, "error", err)
+				if err != nil {
+					log.Info("Error", "kind", req.Kind, "name", req.Name, "delay", result.RequeueAfter, "error", err)
+				} else if result.RequeueAfter == consts.DefaultClusterStatusPollPeriod {
+					log.Info("Stuck", "kind", req.Kind, "name", req.Name, "delay", result.RequeueAfter)
+					requestQueue = slices.Delete(requestQueue, index, index+1)
+				} else if result.Requeue || result.RequeueAfter > 0 {
+					log.Info("Requeue", "kind", req.Kind, "name", req.Name, "delay", result.RequeueAfter)
 				} else {
 					log.Info("Complete", "kind", req.Kind, "name", req.Name)
 					requestQueue = slices.Delete(requestQueue, index, index+1)


### PR DESCRIPTION
Reconciler should return RequeueAfter = DefaultClusterStatusPollPeriod only when it is stuck.

Fix race at checking UpdateIsPossible
Update step shouldn't pass until it see own successful result.
