### PR TITLE
Disable tablet cell decommission while removing them

### DIFF
--- a/pkg/components/ytsaurus_client.go
+++ b/pkg/components/ytsaurus_client.go
@@ -223,15 +223,11 @@ func (yc *YtsaurusClient) handleUpdatingState(ctx context.Context, dry bool) (Co
 
 	case ytv1.UpdateStateWaitingForTabletCellsRemoved:
 		if !yc.ytsaurus.IsUpdateStatusConditionTrue(consts.ConditionTabletCellsRemoved) {
-			removed, err := yc.AreTabletCellsRemoved(ctx)
-			if err != nil {
+			if count, err := yc.AreTabletCellsRemoved(ctx); err != nil {
 				return SimpleStatus(SyncStatusUpdating), err
+			} else if count != 0 {
+				return ComponentStatusUpdating("Waiting for decommission of %v tablet cells", count), nil
 			}
-
-			if !removed {
-				return SimpleStatus(SyncStatusUpdating), nil
-			}
-
 			yc.ytsaurus.SetUpdateStatusCondition(ctx, metav1.Condition{
 				Type:    consts.ConditionTabletCellsRemoved,
 				Status:  metav1.ConditionTrue,
@@ -769,44 +765,36 @@ func (yc *YtsaurusClient) GetTabletCells(ctx context.Context) ([]ytv1.TabletCell
 	return tabletCellBundles, nil
 }
 func (yc *YtsaurusClient) RemoveTabletCells(ctx context.Context) error {
+	logger := log.FromContext(ctx)
 	var tabletCells []string
-	err := yc.ytClient.ListNode(
-		ctx,
-		ypath.Path("//sys/tablet_cells"),
-		&tabletCells,
-		nil)
-
-	if err != nil {
+	if err := yc.ytClient.ListNode(ctx, ypath.Path(consts.TabletCellsPath), &tabletCells, nil); err != nil {
 		return err
 	}
-
+	if len(tabletCells) == 0 {
+		return nil
+	}
+	logger.Info("disabling tablet cell decommission")
+	if err := yc.ytClient.SetNode(ctx, ypath.Path(consts.EnableTabletCellDecommissionPath), false, nil); err != nil {
+		return err
+	}
+	logger.Info("removing tablet cells", "count", len(tabletCells))
+	var err error
 	for _, tabletCell := range tabletCells {
-		err = yc.ytClient.RemoveNode(
-			ctx,
-			ypath.Path(fmt.Sprintf("//sys/tablet_cells/%s", tabletCell)),
-			nil)
+		err = yc.ytClient.RemoveNode(ctx, ypath.Path(consts.TabletCellsPath).Child(tabletCell), nil)
 		if err != nil {
-			return err
+			break
 		}
 	}
-	return nil
+	logger.Info("enabling tablet cell decommission")
+	if err := yc.ytClient.SetNode(ctx, ypath.Path(consts.EnableTabletCellDecommissionPath), true, nil); err != nil {
+		logger.Error(err, "cannot enable tablet cell decommission")
+	}
+	return err
 }
-func (yc *YtsaurusClient) AreTabletCellsRemoved(ctx context.Context) (bool, error) {
+func (yc *YtsaurusClient) AreTabletCellsRemoved(ctx context.Context) (int, error) {
 	var tabletCells []string
-	err := yc.ytClient.ListNode(
-		ctx,
-		ypath.Path("//sys/tablet_cells"),
-		&tabletCells,
-		nil)
-
-	if err != nil {
-		return false, err
-	}
-
-	if len(tabletCells) != 0 {
-		return false, err
-	}
-	return true, nil
+	err := yc.ytClient.ListNode(ctx, ypath.Path(consts.TabletCellsPath), &tabletCells, nil)
+	return len(tabletCells), err
 }
 func (yc *YtsaurusClient) RecoverTableCells(ctx context.Context, bundles []ytv1.TabletCellBundleInfo) error {
 	for _, bundle := range bundles {

--- a/pkg/consts/cypress.go
+++ b/pkg/consts/cypress.go
@@ -19,6 +19,9 @@ const (
 	MasterHydraPath    = "orchid/monitoring/hydra"
 
 	MasterCellDescriptorsPath = "//sys/@config/multicell_manager/cell_descriptors"
+
+	TabletCellsPath                  = "//sys/tablet_cells"
+	EnableTabletCellDecommissionPath = "//sys/@config/tablet_manager/tablet_cell_decommissioner/enable_tablet_cell_decommission"
 )
 
 func ComponentCypressPath(component ComponentType) string {

--- a/test/e2e/helpers_test.go
+++ b/test/e2e/helpers_test.go
@@ -462,8 +462,8 @@ func (c *ClusterHealthReport) Collect(ctx context.Context, ytClient yt.Client) {
 	c.CollectNodes(ctx, ytClient, "//sys/exec_nodes")
 	c.CollectNodes(ctx, ytClient, "//sys/cluster_nodes")
 	c.CollectNodes(ctx, ytClient, "//sys/controller_agents/instances")
-	c.CollectTablets(ctx, ytClient, "//sys/tablet_cell_bundles", []string{"id", "health", "tablet_cell_ids", "tablet_actions", "tablet_cell_life_stage"})
-	c.CollectTablets(ctx, ytClient, "//sys/tablet_cells", []string{"id", "health", "tablet_cell_bundle", "tablet_cell_life_stage", "status"})
+	c.CollectTablets(ctx, ytClient, "//sys/tablet_cell_bundles", []string{"id", "health", "tablet_cell_life_stage", "tablet_cell_count", "tablet_cell_ids", "tablet_actions"})
+	c.CollectTablets(ctx, ytClient, "//sys/tablet_cells", []string{"id", "health", "local_health", "tablet_cell_bundle", "tablet_cell_life_stage", "status", "suspended", "total_statistics", "peers"})
 }
 
 type ClusterComponent struct {


### PR DESCRIPTION
This prevents migration of tablets into remaining tablet cells.
Which is potentially leads to O(N^2) migrations.

Issue: #869
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
