### PR TITLE
Set master max_changelog/snapshot_size_to_keep

### DIFF
--- a/api/v1/ytsaurus_types.go
+++ b/api/v1/ytsaurus_types.go
@@ -528,7 +528,9 @@ type MastersSpec struct {
 
 	HostAddressLabel string `json:"hostAddressLabel,omitempty"`
 
-	MaxSnapshotCountToKeep  *int `json:"maxSnapshotCountToKeep,omitempty"`
+	// Snapshot count to keep, default: 10. Define Quota for MasterSnapshots location to limit by total size.
+	MaxSnapshotCountToKeep *int `json:"maxSnapshotCountToKeep,omitempty"`
+	// Changelog count to keep, default: 10. Define Quota for MasterChangelogs location to limit by total size.
 	MaxChangelogCountToKeep *int `json:"maxChangelogCountToKeep,omitempty"`
 
 	HydraPersistenceUploader *HydraPersistenceUploaderSpec `json:"hydraPersistenceUploader,omitempty"`

--- a/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/config/crd/bases/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -18763,8 +18763,10 @@ spec:
                       type: object
                     type: array
                   maxChangelogCountToKeep:
+                    description: 'Changelog count to keep, default: 10.'
                     type: integer
                   maxSnapshotCountToKeep:
+                    description: 'Snapshot count to keep, default: 10.'
                     type: integer
                   metricExporter:
                     properties:
@@ -28362,8 +28364,10 @@ spec:
                         type: object
                       type: array
                     maxChangelogCountToKeep:
+                      description: 'Changelog count to keep, default: 10.'
                       type: integer
                     maxSnapshotCountToKeep:
+                      description: 'Snapshot count to keep, default: 10.'
                       type: integer
                     metricExporter:
                       properties:

--- a/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
+++ b/config/crd/schema/cluster.ytsaurus.tech_ytsaurus_v1.json
@@ -21867,9 +21867,11 @@
               }
             },
             "maxChangelogCountToKeep": {
+              "description": "Changelog count to keep, default: 10.",
               "type": "integer"
             },
             "maxSnapshotCountToKeep": {
+              "description": "Snapshot count to keep, default: 10.",
               "type": "integer"
             },
             "metricExporter": {
@@ -33052,9 +33054,11 @@
                 }
               },
               "maxChangelogCountToKeep": {
+                "description": "Changelog count to keep, default: 10.",
                 "type": "integer"
               },
               "maxSnapshotCountToKeep": {
+                "description": "Snapshot count to keep, default: 10.",
                 "type": "integer"
               },
               "metricExporter": {

--- a/docs/api.md
+++ b/docs/api.md
@@ -1660,8 +1660,8 @@ _Appears in:_
 | `hostAddresses` _string array_ |  |  |  |
 | `roles` _[MasterCellRole](#mastercellrole)_ | Roles assigned to this master cell. Explicit enlisting is preferred, because defaults could change.<br />In general, assigned or default roles cannot be removed later without risk of data loss. |  | Pattern: `^[a-z_]+$` <br /> |
 | `hostAddressLabel` _string_ |  |  |  |
-| `maxSnapshotCountToKeep` _integer_ |  |  |  |
-| `maxChangelogCountToKeep` _integer_ |  |  |  |
+| `maxSnapshotCountToKeep` _integer_ | Snapshot count to keep, default: 10. Define Quota for MasterSnapshots location to limit by total size. |  |  |
+| `maxChangelogCountToKeep` _integer_ | Changelog count to keep, default: 10. Define Quota for MasterChangelogs location to limit by total size. |  |  |
 | `hydraPersistenceUploader` _[HydraPersistenceUploaderSpec](#hydrapersistenceuploaderspec)_ |  |  |  |
 | `timbertruck` _[TimbertruckSpec](#timbertruckspec)_ |  |  |  |
 | `sidecars` _string array_ | List of sidecar containers as yaml of core/v1 Container. |  |  |

--- a/pkg/consts/defaults.go
+++ b/pkg/consts/defaults.go
@@ -44,3 +44,6 @@ const DefaultTimbertruckDirectoryPath = "//sys/admin/logs"
 const DefaultImageHeaterConcurrency = 100
 
 const DefaultClusterStatusPollPeriod = time.Minute
+
+const DefaultMasterChangelogsCountToKeep = 10
+const DefaultMasterSnapshotsCountToKeep = 10

--- a/pkg/ytconfig/master.go
+++ b/pkg/ytconfig/master.go
@@ -19,8 +19,10 @@ type MasterSnapshots struct {
 }
 
 type HydraManager struct {
-	MaxChangelogCountToKeep int `yson:"max_changelog_count_to_keep"`
-	MaxSnapshotCountToKeep  int `yson:"max_snapshot_count_to_keep"`
+	MaxChangelogCountToKeep int    `yson:"max_changelog_count_to_keep"`
+	MaxChangelogSizeToKeep  *int64 `yson:"max_changelog_size_to_keep,omitempty"`
+	MaxSnapshotCountToKeep  int    `yson:"max_snapshot_count_to_keep"`
+	MaxSnapshotSizeToKeep   *int64 `yson:"max_snapshot_size_to_keep,omitempty"`
 }
 
 type CypressManager struct {
@@ -63,25 +65,23 @@ func getMasterServerCarcass(spec *ytv1.MastersSpec) (MasterServer, error) {
 	c.RPCPort = consts.MasterRPCPort
 	c.MonitoringPort = ptr.Deref(spec.MonitoringPort, consts.MasterMonitoringPort)
 
-	c.HydraManager.MaxSnapshotCountToKeep = 10
-	if spec.MaxSnapshotCountToKeep != nil {
-		c.HydraManager.MaxSnapshotCountToKeep = *spec.MaxSnapshotCountToKeep
-	}
-	c.HydraManager.MaxChangelogCountToKeep = 10
-	if spec.MaxChangelogCountToKeep != nil {
-		c.HydraManager.MaxChangelogCountToKeep = *spec.MaxChangelogCountToKeep
-	}
-
-	c.SecondaryMasters = nil
+	c.HydraManager.MaxChangelogCountToKeep = ptr.Deref(spec.MaxChangelogCountToKeep, int(consts.DefaultMasterChangelogsCountToKeep))
+	c.HydraManager.MaxSnapshotCountToKeep = ptr.Deref(spec.MaxSnapshotCountToKeep, int(consts.DefaultMasterSnapshotsCountToKeep))
 
 	if location := ytv1.FindFirstLocation(spec.Locations, ytv1.LocationTypeMasterChangelogs); location != nil {
 		c.Changelogs.Path = location.Path
+		if location.Quota != nil {
+			c.HydraManager.MaxChangelogSizeToKeep = ptr.To(location.Quota.Value())
+		}
 	} else {
 		return c, fmt.Errorf("error creating master config: changelog location not found")
 	}
 
 	if location := ytv1.FindFirstLocation(spec.Locations, ytv1.LocationTypeMasterSnapshots); location != nil {
 		c.Snapshots.Path = location.Path
+		if location.Quota != nil {
+			c.HydraManager.MaxSnapshotSizeToKeep = ptr.To(location.Quota.Value())
+		}
 	} else {
 		return c, fmt.Errorf("error creating master config: snapshot location not found")
 	}

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-2-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-2-config.yaml
@@ -238,8 +238,10 @@ data:
         };
         "use_new_hydra"=%true;
         "hydra_manager"={
-            "max_changelog_count_to_keep"=10;
-            "max_snapshot_count_to_keep"=10;
+            "max_changelog_count_to_keep"=12;
+            "max_changelog_size_to_keep"=1073741824;
+            "max_snapshot_count_to_keep"=11;
+            "max_snapshot_size_to_keep"=3221225472;
         };
         "cypress_manager"={
             "default_table_replication_factor"=3;

--- a/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-config.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/ConfigMap yt-master-config.yaml
@@ -252,8 +252,10 @@ data:
         };
         "use_new_hydra"=%true;
         "hydra_manager"={
-            "max_changelog_count_to_keep"=10;
-            "max_snapshot_count_to_keep"=10;
+            "max_changelog_count_to_keep"=12;
+            "max_changelog_size_to_keep"=1073741824;
+            "max_snapshot_count_to_keep"=11;
+            "max_snapshot_size_to_keep"=3221225472;
         };
         "cypress_manager"={
             "default_table_replication_factor"=3;

--- a/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
+++ b/test/r8r/canondata/Components reconciler With all components Test/Ytsaurus.yaml
@@ -391,8 +391,10 @@ spec:
     locations:
     - locationType: MasterChangelogs
       path: /yt/master-data/master-changelogs
+      quota: 1Gi
     - locationType: MasterSnapshots
       path: /yt/master-data/master-snapshots
+      quota: 3Gi
     - locationType: Logs
       path: /yt/master-logs
     - locationType: InitJobLogs
@@ -418,6 +420,8 @@ spec:
         maxTotalSizeToKeep: 1Gi
       useTimestampSuffix: false
       writerType: file
+    maxChangelogCountToKeep: 12
+    maxSnapshotCountToKeep: 11
     minReadyInstanceCount: 0
     nodeSelector:
       instance-node-selector: "true"
@@ -665,8 +669,10 @@ spec:
     locations:
     - locationType: MasterChangelogs
       path: /yt/master-data/master-changelogs
+      quota: 1Gi
     - locationType: MasterSnapshots
       path: /yt/master-data/master-snapshots
+      quota: 3Gi
     - locationType: Logs
       path: /yt/master-logs
     - locationType: InitJobLogs
@@ -690,6 +696,8 @@ spec:
         maxTotalSizeToKeep: 1Gi
       useTimestampSuffix: false
       writerType: file
+    maxChangelogCountToKeep: 12
+    maxSnapshotCountToKeep: 11
     minReadyInstanceCount: 0
     resources:
       limits:

--- a/test/r8r/components_test.go
+++ b/test/r8r/components_test.go
@@ -24,6 +24,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/types"
@@ -662,6 +663,11 @@ var _ = Describe("Components reconciler", Label("reconciler"), func() {
 			ytBuilder.DebugLogs = true
 			ytBuilder.CreateMinimal()
 			ytsaurus = ytBuilder.Ytsaurus
+
+			ytsaurus.Spec.PrimaryMasters.MaxChangelogCountToKeep = ptr.To(12)
+			ytsaurus.Spec.PrimaryMasters.MaxSnapshotCountToKeep = ptr.To(11)
+			ytsaurus.Spec.PrimaryMasters.Locations[0].Quota = ptr.To(resource.MustParse("1Gi"))
+			ytsaurus.Spec.PrimaryMasters.Locations[1].Quota = ptr.To(resource.MustParse("3Gi"))
 
 			ytBuilder.WithAdminUser()
 			ytBuilder.WithOverrides()

--- a/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
+++ b/ytop-chart/templates/crds/cluster.ytsaurus.tech_ytsaurus.yaml
@@ -18768,8 +18768,10 @@ spec:
                       type: object
                     type: array
                   maxChangelogCountToKeep:
+                    description: 'Changelog count to keep, default: 10.'
                     type: integer
                   maxSnapshotCountToKeep:
+                    description: 'Snapshot count to keep, default: 10.'
                     type: integer
                   metricExporter:
                     properties:
@@ -28367,8 +28369,10 @@ spec:
                         type: object
                       type: array
                     maxChangelogCountToKeep:
+                      description: 'Changelog count to keep, default: 10.'
                       type: integer
                     maxSnapshotCountToKeep:
+                      description: 'Snapshot count to keep, default: 10.'
                       type: integer
                     metricExporter:
                       properties:


### PR DESCRIPTION
Use Quota set for MasterSnapshots and MasterChangelogs locations as limits.

Closes: #877
Signed-off-by: Konstantin Khlebnikov <khlebnikov@nebius.com>
